### PR TITLE
Remove validation for device naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup | Rust toolchain
         uses: dtolnay/rust-toolchain@1.90.0
         with:
-          toolchain: 1.87.0
+          toolchain: 1.90.0
           components: clippy, rustfmt, llvm-tools-preview
 
       - name: Setup | Rust cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt-get update
 
       - name: Setup | Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.90.0
         with:
           toolchain: 1.87.0
           components: clippy, rustfmt, llvm-tools-preview

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.90"
+components = ["clippy", "rust-analyzer", "rustfmt"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,9 +16,6 @@ pub enum ShapleyError {
     #[error("Too many operators: {count} (limit is {limit})")]
     TooManyOperators { count: usize, limit: usize },
 
-    #[error("Invalid device label: {0}")]
-    InvalidDeviceLabel(String),
-
     #[error("Invalid city label: {0}")]
     InvalidCityLabel(String),
 

--- a/src/shapley.rs
+++ b/src/shapley.rs
@@ -307,10 +307,10 @@ fn compute_expected_values(
     }
 
     // The Python implementation has a special case for the empty coalition's value
-    if let Some(v) = svalue[0] {
-        if v.is_finite() {
-            evalue[0] = v;
-        }
+    if let Some(v) = svalue[0]
+        && v.is_finite()
+    {
+        evalue[0] = v;
     }
 
     Ok(evalue)

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -51,33 +51,6 @@ pub(crate) fn check_inputs(
         ));
     }
 
-    for link in private_links {
-        if !has_digit(&link.device1) {
-            return Err(ShapleyError::InvalidDeviceLabel(format!(
-                "Device {} should contain a digit",
-                link.device1
-            )));
-        }
-        if !has_digit(&link.device2) {
-            return Err(ShapleyError::InvalidDeviceLabel(format!(
-                "Device {} should contain a digit",
-                link.device2
-            )));
-        }
-        if link.device1.ends_with("00") {
-            return Err(ShapleyError::InvalidDeviceLabel(format!(
-                "Device {} should not have a 00 code",
-                link.device1
-            )));
-        }
-        if link.device2.ends_with("00") {
-            return Err(ShapleyError::InvalidDeviceLabel(format!(
-                "Device {} should not have a 00 code",
-                link.device2
-            )));
-        }
-    }
-
     // Check that public links table is labeled correctly
     for link in public_links {
         if has_digit(&link.city1) {

--- a/tests/telemetry_device_validation.rs
+++ b/tests/telemetry_device_validation.rs
@@ -214,8 +214,8 @@ fn test_mixed_format_device_names() {
 }
 
 #[test]
-fn test_device_names_still_require_digits() {
-    // Verify that device names without digits are still rejected
+fn test_device_names_without_digits_are_allowed() {
+    // Device names may omit digits; ensure they pass validation
     let devices = vec![
         Device::new("nyc-dz-abc".to_string(), 10, "Alpha".to_string()), // no digits
         Device::new("LON1".to_string(), 10, "Beta".to_string()),
@@ -253,8 +253,5 @@ fn test_device_names_still_require_digits() {
     };
 
     let result = input.compute();
-    assert!(
-        result.is_err(),
-        "Device names without digits should still be rejected"
-    );
+    assert!(result.is_ok());
 }

--- a/tests/validation_errors.rs
+++ b/tests/validation_errors.rs
@@ -176,7 +176,7 @@ fn test_empty_private_links_rejected() {
 }
 
 #[test]
-fn test_device_without_digit_rejected() {
+fn test_device_without_digit_allowed() {
     let devices = vec![
         Device::new("NYCX".to_string(), 10, "Alpha".to_string()), // No digit
         Device::new("LON1".to_string(), 10, "Beta".to_string()),
@@ -203,18 +203,14 @@ fn test_device_without_digit_rejected() {
     };
 
     let result = input.compute();
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        ShapleyError::InvalidDeviceLabel(msg) => {
-            assert!(msg.contains("NYCX"));
-            assert!(msg.contains("should contain a digit"));
-        }
-        _ => panic!("Expected InvalidDeviceLabel error"),
-    }
+    assert!(
+        result.is_ok(),
+        "Device labels without digits should no longer trigger validation errors",
+    );
 }
 
 #[test]
-fn test_device_with_00_code_rejected() {
+fn test_device_with_00_code_allowed() {
     let devices = vec![
         Device::new("NYC00".to_string(), 10, "Alpha".to_string()), // Has 00 code
         Device::new("LON1".to_string(), 10, "Beta".to_string()),
@@ -241,14 +237,10 @@ fn test_device_with_00_code_rejected() {
     };
 
     let result = input.compute();
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        ShapleyError::InvalidDeviceLabel(msg) => {
-            assert!(msg.contains("NYC00"));
-            assert!(msg.contains("should not have a 00 code"));
-        }
-        _ => panic!("Expected InvalidDeviceLabel error"),
-    }
+    assert!(
+        result.is_ok(),
+        "Device labels ending in '00' should no longer trigger validation errors",
+    );
 }
 
 // Note: 2-letter cities are allowed - removing this test


### PR DESCRIPTION
Summary
----
This PR removes explicit validation for device name (pvt links). This validation is not necessary as we don't want to enforce contributors putting in specifically formatted device codes.