### PR TITLE
perf(solver): replace string cmp with bitmasks in coalition loop

### DIFF
--- a/src/multicast.rs
+++ b/src/multicast.rs
@@ -3,6 +3,7 @@ use crate::{
     sparse::CscMatrix,
     types::ConsolidatedLink,
 };
+use std::collections::HashMap;
 
 /// Build J1 matrix - all private links grouped by shared ID
 pub(crate) fn build_j1_matrix(
@@ -57,46 +58,29 @@ pub(crate) fn compute_j1_minus_j2(
         ));
     }
 
-    // Build triplets for the difference
-    let mut triplets = Vec::new();
+    // Accumulate entries in a HashMap for O(nnz) performance
+    let mut entries: HashMap<(usize, usize), f64> = HashMap::new();
 
     // Add J1 entries
     for col in 0..j1.n {
-        let start = j1.colptr[col];
-        let end = j1.colptr[col + 1];
-
-        for idx in start..end {
-            let row = j1.rowval[idx];
-            let val = j1.nzval[idx];
-            triplets.push((row, col, val));
+        for idx in j1.colptr[col]..j1.colptr[col + 1] {
+            *entries.entry((j1.rowval[idx], col)).or_default() += j1.nzval[idx];
         }
     }
 
     // Subtract J2 entries
     for col in 0..j2.n {
-        let start = j2.colptr[col];
-        let end = j2.colptr[col + 1];
-
-        for idx in start..end {
-            let row = j2.rowval[idx];
-            let val = j2.nzval[idx];
-            // Find if this (row, col) exists in triplets and subtract
-            let mut found = false;
-            for triplet in &mut triplets {
-                if triplet.0 == row && triplet.1 == col {
-                    triplet.2 -= val;
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                triplets.push((row, col, -val));
-            }
+        for idx in j2.colptr[col]..j2.colptr[col + 1] {
+            *entries.entry((j2.rowval[idx], col)).or_default() -= j2.nzval[idx];
         }
     }
 
-    // Remove zero entries
-    triplets.retain(|&(_, _, val)| val.abs() > 1e-10);
+    // Remove near-zero entries and convert to triplets
+    entries.retain(|_, v| v.abs() > 1e-10);
+    let triplets: Vec<(usize, usize, f64)> = entries
+        .into_iter()
+        .map(|((row, col), val)| (row, col, val))
+        .collect();
 
     build_csc_from_triplets(&triplets, j1.m, j1.n)
 }

--- a/src/shapley.rs
+++ b/src/shapley.rs
@@ -4,12 +4,12 @@ use crate::{
     lp_builder::LpBuilderInput,
     solver::{SolveStatus, create_coalition_solver},
     types::{Demands, Devices, PrivateLinks, PublicLinks},
-    utils::{factorial, generate_bitmap},
+    utils::factorial,
     validation::check_inputs,
 };
 use rayon::prelude::*;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     fmt::{Display, Formatter},
 };
 
@@ -18,6 +18,11 @@ use {
     serde::{Deserialize, Serialize},
     tabled::Tabled,
 };
+
+/// Sentinel bit for operators that are always included in every coalition
+/// (Public, Private, empty). Set in bit 31 so it never collides with
+/// operator index bits 0..19.
+const ALWAYS_BIT: u32 = 1 << 31;
 
 // For clarity
 pub type Operator = String;
@@ -149,30 +154,59 @@ impl Shapley {
         // Build LP primitives
         let primitives = LpBuilderInput::new(&full_map, &full_demand).build()?;
 
-        // Generate coalition bitmap
-        let bitmap = generate_bitmap(n_operators);
+        // Pre-compute operator bitmasks (once, before the parallel loop)
+        let op_index: HashMap<&str, u8> = operators
+            .iter()
+            .enumerate()
+            .map(|(i, op)| (op.as_str(), i as u8))
+            .collect();
+
+        let operator_mask = |op: &str| -> u32 {
+            if op == "Public" || op == "Private" || op.is_empty() {
+                ALWAYS_BIT
+            } else if let Some(&idx) = op_index.get(op) {
+                1u32 << idx
+            } else {
+                0
+            }
+        };
+
+        let col_op1_mask: Vec<u32> = primitives
+            .col_op1
+            .iter()
+            .map(|s| operator_mask(s))
+            .collect();
+        let col_op2_mask: Vec<u32> = primitives
+            .col_op2
+            .iter()
+            .map(|s| operator_mask(s))
+            .collect();
+        let row_op1_mask: Vec<u32> = primitives
+            .row_op1
+            .iter()
+            .map(|s| operator_mask(s))
+            .collect();
+        let row_op2_mask: Vec<u32> = primitives
+            .row_op2
+            .iter()
+            .map(|s| operator_mask(s))
+            .collect();
+
         let n_coalitions = 1 << n_operators;
 
         // Solve LP for each coalition
         let coalition_values: Vec<Option<f64>> = (0..n_coalitions)
             .into_par_iter()
             .map(|coalition_idx| {
-                // Check which operators are in this coalition
-                let mut coalition_operators = Vec::new();
-                for (op_idx, operator) in operators.iter().enumerate() {
-                    if (coalition_idx & (1 << op_idx)) != 0 {
-                        coalition_operators.push(operator.clone());
-                    }
-                }
-
-                // Create solver for this coalition
-                let coalition_bitmap = coalition_idx as u32;
+                let coalition_mask = (coalition_idx as u32) | ALWAYS_BIT;
 
                 match create_coalition_solver(
                     &primitives,
-                    coalition_bitmap,
-                    &primitives.col_op1,
-                    &coalition_operators,
+                    coalition_mask,
+                    &col_op1_mask,
+                    &col_op2_mask,
+                    &row_op1_mask,
+                    &row_op2_mask,
                 ) {
                     Ok(solver) => {
                         // Solve and return the optimal value
@@ -204,8 +238,7 @@ impl Shapley {
         };
 
         // Compute Shapley values
-        let shapley_values =
-            compute_shapley_values(&expected_values, &bitmap, n_operators, &operators);
+        let shapley_values = compute_shapley_values(&expected_values, n_operators);
 
         // Convert to output format
         let total_value: f64 = shapley_values.iter().map(|v| v.max(0.0)).sum();
@@ -283,24 +316,16 @@ fn compute_expected_values(
 }
 
 /// Compute Shapley values from coalition values
-fn compute_shapley_values(
-    coalition_values: &[f64],
-    bitmap: &[Vec<u8>],
-    n_operators: usize,
-    operators: &[String],
-) -> Vec<f64> {
+fn compute_shapley_values(coalition_values: &[f64], n_operators: usize) -> Vec<f64> {
     let mut shapley_values = vec![0.0; n_operators];
     let fact_n = factorial(n_operators);
 
-    for (k, _operator) in operators.iter().enumerate() {
+    for (k, sv) in shapley_values.iter_mut().enumerate() {
         let mut value = 0.0;
 
         // Find coalitions with this operator
-        for coalition_idx in 0..coalition_values.len() {
-            if bitmap[k][coalition_idx] == 1 {
-                // Coalition with operator
-                let with_value = coalition_values[coalition_idx];
-
+        for (coalition_idx, &with_value) in coalition_values.iter().enumerate() {
+            if (coalition_idx >> k) & 1 == 1 {
                 // Coalition without operator (remove bit k)
                 let without_idx = coalition_idx ^ (1 << k);
                 let without_value = coalition_values[without_idx];
@@ -317,7 +342,7 @@ fn compute_shapley_values(
             }
         }
 
-        shapley_values[k] = value;
+        *sv = value;
     }
 
     shapley_values

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -39,31 +39,36 @@ fn rows_from_csc(matrix: &CscMatrix<f64>) -> Vec<Vec<(usize, f64)>> {
 }
 
 impl LpSolver {
-    /// Create a new LP solver from primitives
-    pub(crate) fn new(primitives: &LpPrimitives) -> Result<Self> {
+    /// Create a new LP solver from individual components
+    pub(crate) fn new(
+        cost: &[f64],
+        a_eq: &CscMatrix<f64>,
+        b_eq: &[f64],
+        a_ub: &CscMatrix<f64>,
+        b_ub: &[f64],
+    ) -> Result<Self> {
         let mut problem = microlp::Problem::new(OptimizationDirection::Minimize);
 
         // Add variables with cost coefficients and non-negativity bounds
-        let vars: Vec<Variable> = primitives
-            .cost
+        let vars: Vec<Variable> = cost
             .iter()
             .map(|&c| problem.add_var(c, (0.0, f64::INFINITY)))
             .collect();
 
         // Add equality constraints (A_eq * x = b_eq)
-        let eq_rows = rows_from_csc(&primitives.a_eq);
+        let eq_rows = rows_from_csc(a_eq);
         for (row_idx, entries) in eq_rows.iter().enumerate() {
             let terms: Vec<(Variable, f64)> =
                 entries.iter().map(|&(col, val)| (vars[col], val)).collect();
-            problem.add_constraint(&terms, ComparisonOp::Eq, primitives.b_eq[row_idx]);
+            problem.add_constraint(&terms, ComparisonOp::Eq, b_eq[row_idx]);
         }
 
         // Add inequality constraints (A_ub * x <= b_ub)
-        let ub_rows = rows_from_csc(&primitives.a_ub);
+        let ub_rows = rows_from_csc(a_ub);
         for (row_idx, entries) in ub_rows.iter().enumerate() {
             let terms: Vec<(Variable, f64)> =
                 entries.iter().map(|&(col, val)| (vars[col], val)).collect();
-            problem.add_constraint(&terms, ComparisonOp::Le, primitives.b_ub[row_idx]);
+            problem.add_constraint(&terms, ComparisonOp::Le, b_ub[row_idx]);
         }
 
         Ok(Self { problem })
@@ -85,29 +90,22 @@ impl LpSolver {
     }
 }
 
-/// Create LP solver for a specific coalition
+/// Create LP solver for a specific coalition using precomputed bitmasks.
+///
+/// `coalition_mask` has bit i set for each operator i in the coalition,
+/// plus `ALWAYS_BIT` so that Public/Private/empty operators always match.
 pub(crate) fn create_coalition_solver(
     primitives: &LpPrimitives,
-    _coalition_bitmap: u32,
-    col_op1: &[String],
-    coalition_operators: &[String],
+    coalition_mask: u32,
+    col_op1_mask: &[u32],
+    col_op2_mask: &[u32],
+    row_op1_mask: &[u32],
+    row_op2_mask: &[u32],
 ) -> Result<LpSolver> {
-    // Always include "Public" and "Private" operators
-    let always_included = ["Public", "Private"];
-
-    // Filter columns based on coalition membership
-    // A column is included if BOTH col_op1 AND col_op2 are in coalition (or always included)
-    let keep_cols: Vec<usize> = (0..col_op1.len())
+    // Filter columns: keep if BOTH operators match the coalition
+    let keep_cols: Vec<usize> = (0..col_op1_mask.len())
         .filter(|&i| {
-            let op1 = &primitives.col_op1[i];
-            let op2 = &primitives.col_op2[i];
-
-            let op1_included =
-                always_included.contains(&op1.as_str()) || coalition_operators.contains(op1);
-            let op2_included =
-                always_included.contains(&op2.as_str()) || coalition_operators.contains(op2);
-
-            op1_included && op2_included
+            (col_op1_mask[i] & coalition_mask) != 0 && (col_op2_mask[i] & coalition_mask) != 0
         })
         .collect();
 
@@ -117,30 +115,10 @@ pub(crate) fn create_coalition_solver(
         ));
     }
 
-    // Determine if this is the grand coalition (contains all operators)
-    // First, collect all unique operators from row_op1 and row_op2 (excluding empty, Public, Private)
-    let mut all_operators = std::collections::HashSet::new();
-    for op in primitives.row_op1.iter().chain(primitives.row_op2.iter()) {
-        if !op.is_empty() && op != "Public" && op != "Private" {
-            all_operators.insert(op.as_str());
-        }
-    }
-
-    // Filter rows for A_ub based on coalition membership
-    // A row is included if BOTH row_op1 AND row_op2 are in coalition (or always included)
-    let keep_rows: Vec<usize> = (0..primitives.row_op1.len())
+    // Filter rows for A_ub: keep if BOTH operators match the coalition
+    let keep_rows: Vec<usize> = (0..row_op1_mask.len())
         .filter(|&i| {
-            let op1 = &primitives.row_op1[i];
-            let op2 = &primitives.row_op2[i];
-
-            // Include constraints if both operators are in the coalition or if operators are empty (universal constraints)
-            let op1_included = op1.is_empty()
-                || always_included.contains(&op1.as_str())
-                || coalition_operators.contains(op1);
-            let op2_included = op2.is_empty()
-                || always_included.contains(&op2.as_str())
-                || coalition_operators.contains(op2);
-            op1_included && op2_included
+            (row_op1_mask[i] & coalition_mask) != 0 && (row_op2_mask[i] & coalition_mask) != 0
         })
         .collect();
 
@@ -162,32 +140,13 @@ pub(crate) fn create_coalition_solver(
         .copied()
         .collect();
 
-    // Create new primitives with filtered data
-    let filtered_primitives = LpPrimitives {
-        a_eq: a_eq_filtered,
-        a_ub: a_ub_filtered,
-        b_eq: primitives.b_eq.clone(),
-        b_ub: b_ub_filtered,
-        cost: cost_filtered,
-        row_op1: keep_rows
-            .iter()
-            .filter_map(|&i| primitives.row_op1.get(i).cloned())
-            .collect(),
-        row_op2: keep_rows
-            .iter()
-            .filter_map(|&i| primitives.row_op2.get(i).cloned())
-            .collect(),
-        col_op1: keep_cols
-            .iter()
-            .filter_map(|&i| primitives.col_op1.get(i).cloned())
-            .collect(),
-        col_op2: keep_cols
-            .iter()
-            .filter_map(|&i| primitives.col_op2.get(i).cloned())
-            .collect(),
-    };
-
-    LpSolver::new(&filtered_primitives)
+    LpSolver::new(
+        &cost_filtered,
+        &a_eq_filtered,
+        &primitives.b_eq,
+        &a_ub_filtered,
+        &b_ub_filtered,
+    )
 }
 
 /// Filter columns of a CSC matrix
@@ -307,7 +266,13 @@ mod tests {
         let primitives = lp_builder
             .build()
             .expect("LP builder should succeed in tests");
-        let solver = LpSolver::new(&primitives);
+        let solver = LpSolver::new(
+            &primitives.cost,
+            &primitives.a_eq,
+            &primitives.b_eq,
+            &primitives.a_ub,
+            &primitives.b_ub,
+        );
 
         assert!(solver.is_ok());
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,20 +3,6 @@ pub(crate) fn has_digit(s: &str) -> bool {
     s.chars().any(|c| c.is_ascii_digit())
 }
 
-/// Generate a bitmap where column j is the binary representation of j
-pub(crate) fn generate_bitmap(n_bits: usize) -> Vec<Vec<u8>> {
-    let n_cols = 1 << n_bits;
-    let mut bitmap = vec![vec![0u8; n_cols]; n_bits];
-
-    for col in 0..n_cols {
-        for (row, row_bitmap) in bitmap.iter_mut().enumerate().take(n_bits) {
-            row_bitmap[col] = ((col >> row) & 1) as u8;
-        }
-    }
-
-    bitmap
-}
-
 /// Calculate factorial (cached for small values)
 pub(crate) const FACTORIAL_LIMIT: usize = 21;
 pub(crate) const FACTORIALS: [u64; FACTORIAL_LIMIT] = {


### PR DESCRIPTION
# Summary

This PR replaces per-coalition string comparisons with precomputed u32 bitmasks, eliminating O(n) `Vec::contains()` calls in the hot parallel loop across all 2^n coalitions.

## Changes
- Pre-compute operator bitmasks once before the parallel loop; coalition membership is now a single bitwise AND per column/row
- Introduce `ALWAYS_BIT` (bit 31) sentinel so Public/Private/empty operators pass membership checks without special-casing
- Replace O(nnz²) linear scan in `compute_j1_minus_j2` with O(nnz) `HashMap`-based accumulation
- Remove `generate_bitmap()` — inline `(coalition_idx >> k) & 1` replaces the pre-allocated bitmap matrix
- `LpSolver::new()` takes individual slices instead of `&LpPrimitives`, avoiding cloned operator strings in filtered structs
- Remove dead code (`generate_bitmap` in utils.rs)
