### PR TITLE
Performance optimizations, parity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,20 @@ jobs:
       - name: Setup | Just
         uses: taiki-e/install-action@just
 
+      - name: Setup | Python (for parity test)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup | Python deps
+        run: pip install pandas scipy
+
+      - name: Setup | Clone Python reference implementation
+        run: git clone https://github.com/doublezerofoundation/network-shapley.git ../network-shapley-py
+
       - name: Test | CI Pipeline
+        env:
+          NETWORK_SHAPLEY_PY_PATH: ../network-shapley-py
         run: just ci
 
       - name: Coverage | Collect coverage data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -215,8 +215,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "sprs",
  "tabled",
  "thiserror",
+ "web-time",
 ]
 
 [[package]]
@@ -271,9 +273,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -355,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -428,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,9 +523,9 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -534,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -544,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -557,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "network-shapley"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ borsh = { version = "1", features = [ "derive" ] ,optional = true }
 csv = { version = "1", optional = true }
 microlp = "0.4"
 rayon = "1"
+sprs = { version = "0.11.4", default-features = false }
+web-time = "1.1.0"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 tabled = { version = "0", optional = true, features = [ "std" ]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-shapley"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [[bin]]

--- a/codecov.yml
+++ b/codecov.yml
@@ -40,3 +40,4 @@ ignore:
   - "tests/"
   - "benches/"
   - "examples/"
+  - "src/simplex/"  # Vendored microlp solver internals — tested upstream

--- a/examples/csv_demand1.rs
+++ b/examples/csv_demand1.rs
@@ -1,9 +1,10 @@
+use std::fs::File;
+
 use network_shapley::{
     error::Result,
     shapley::ShapleyInput,
     types::{Demand, Demands, Device, Devices, PrivateLink, PrivateLinks, PublicLink, PublicLinks},
 };
-use std::fs::File;
 use tabled::{builder::Builder as TableBuilder, settings::Style};
 
 fn read_pvt_links(file_path: &str) -> Result<PrivateLinks> {

--- a/examples/csv_demand2.rs
+++ b/examples/csv_demand2.rs
@@ -1,9 +1,10 @@
+use std::fs::File;
+
 use network_shapley::{
     error::Result,
     shapley::ShapleyInput,
     types::{Demand, Demands, Device, Devices, PrivateLink, PrivateLinks, PublicLink, PublicLinks},
 };
-use std::fs::File;
 use tabled::{builder::Builder as TableBuilder, settings::Style};
 
 fn read_pvt_links(file_path: &str) -> Result<PrivateLinks> {

--- a/src/bin/shapley_cli.rs
+++ b/src/bin/shapley_cli.rs
@@ -1,9 +1,10 @@
-use network_shapley::shapley::{ShapleyInput, ShapleyValue};
-use serde::Serialize;
 use std::{
     io::{self, Read},
     process::ExitCode,
 };
+
+use network_shapley::shapley::{ShapleyInput, ShapleyValue};
+use serde::Serialize;
 
 #[derive(Serialize)]
 struct OperatorValue {

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -1,8 +1,9 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
 use crate::{
     error::{Result, ShapleyError},
     types::{ConsolidatedDemand, ConsolidatedLink, Demands, Devices, PrivateLinks, PublicLinks},
 };
-use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Consolidate demand table for LP construction
 pub(crate) fn consolidate_demand(
@@ -195,8 +196,13 @@ pub(crate) fn consolidate_links(
             .get(link.device2.as_str())
             .unwrap_or(&"Unknown");
 
-        // Adjust bandwidth for uptime
-        let adjusted_bandwidth = link.bandwidth * link.uptime;
+        // Adjust bandwidth using quadratic uptime penalty curve.
+        // Maps raw uptime to effective availability — heavily penalizes below 98%:
+        //   100% → 1.0, 99% → ~0.66, 98% → ~0, <98% → 0
+        let uptime_factor = (-1578.9474 * link.uptime.powi(2) + 3176.3158 * link.uptime
+            - 1596.3684)
+            .clamp(0.0, 1.0);
+        let adjusted_bandwidth = link.bandwidth * uptime_factor;
 
         consolidated.push(ConsolidatedLink {
             device1: link.device1.clone(),

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -542,4 +542,88 @@ mod tests {
             multicast_types.iter().cloned().collect();
         assert_eq!(unique_multicast_types.len(), multicast_types.len());
     }
+
+    #[test]
+    fn test_uptime_penalty_perfect() {
+        // 100% uptime → factor = 1.0 (no penalty)
+        let factor =
+            (-1578.9474_f64 * 1.0_f64.powi(2) + 3176.3158 * 1.0 - 1596.3684).clamp(0.0, 1.0);
+        assert!((factor - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_uptime_penalty_99_percent() {
+        // 99% uptime → ~0.66
+        let factor =
+            (-1578.9474_f64 * 0.99_f64.powi(2) + 3176.3158 * 0.99 - 1596.3684).clamp(0.0, 1.0);
+        assert!(
+            factor > 0.6 && factor < 0.7,
+            "99% uptime should be ~0.66, got {factor}"
+        );
+    }
+
+    #[test]
+    fn test_uptime_penalty_98_percent_drops_to_zero() {
+        // 98% uptime → ~0 (threshold)
+        let factor =
+            (-1578.9474_f64 * 0.98_f64.powi(2) + 3176.3158 * 0.98 - 1596.3684).clamp(0.0, 1.0);
+        assert!(factor < 0.01, "98% uptime should be ~0, got {factor}");
+    }
+
+    #[test]
+    fn test_uptime_penalty_below_98_is_zero() {
+        for uptime in [0.97_f64, 0.95, 0.90, 0.50, 0.0] {
+            let factor =
+                (-1578.9474_f64 * uptime.powi(2) + 3176.3158 * uptime - 1596.3684).clamp(0.0, 1.0);
+            assert_eq!(
+                factor, 0.0,
+                "{uptime} uptime should clamp to 0, got {factor}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_uptime_penalty_applied_to_bandwidth() {
+        // Verify consolidate_links applies the penalty to bandwidth
+        // Device names must be 3+ chars (code slices [..3] for city prefix)
+        let private_links = vec![crate::types::PrivateLink::new(
+            "AAA1".to_string(),
+            "BBB1".to_string(),
+            10.0,
+            100.0,
+            0.99, // 99% uptime → ~66% bandwidth
+            Some(1),
+        )];
+        let devices = vec![
+            crate::types::Device::new("AAA1".to_string(), 10, "Op1".to_string()),
+            crate::types::Device::new("BBB1".to_string(), 10, "Op1".to_string()),
+        ];
+        let demands = vec![ConsolidatedDemand {
+            start: "A".to_string(),
+            end: "B".to_string(),
+            receivers: 1,
+            traffic: 1.0,
+            priority: 1.0,
+            kind: 1,
+            multicast: false,
+            original: 1,
+        }];
+        let public_links = vec![];
+
+        let result = consolidate_links(&private_links, &devices, &demands, &public_links, 5.0)
+            .expect("consolidate_links should succeed");
+
+        // Find the AAA1→BBB1 link (forward direction)
+        let ab_link = result
+            .iter()
+            .find(|l| l.device1 == "AAA1" && l.device2 == "BBB1");
+        assert!(ab_link.is_some(), "Should have AAA1→BBB1 link");
+
+        let bw = ab_link.unwrap().bandwidth;
+        // 100 * ~0.66 = ~66 (not 100 * 0.99 = 99)
+        assert!(
+            bw > 60.0 && bw < 70.0,
+            "Bandwidth should be ~66 (penalized), got {bw}"
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub(crate) mod lp_builder;
 pub(crate) mod multicast;
 pub mod shapley;
+pub(crate) mod simplex;
 pub(crate) mod solver;
 pub(crate) mod sparse;
 pub mod types;

--- a/src/lp_builder.rs
+++ b/src/lp_builder.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
 use crate::{
     error::{Result, ShapleyError},
     multicast::{
@@ -7,7 +9,6 @@ use crate::{
     sparse::CscMatrix,
     types::{ConsolidatedDemand, ConsolidatedLink},
 };
-use std::collections::{BTreeMap, HashMap, HashSet};
 
 type Constraints = (CscMatrix<f64>, Vec<f64>, Vec<String>, Vec<String>);
 

--- a/src/multicast.rs
+++ b/src/multicast.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
+
 use crate::{
     error::{Result, ShapleyError},
     sparse::CscMatrix,
     types::ConsolidatedLink,
 };
-use std::collections::HashMap;
 
 /// Build J1 matrix - all private links grouped by shared ID
 pub(crate) fn build_j1_matrix(

--- a/src/shapley.rs
+++ b/src/shapley.rs
@@ -1,22 +1,24 @@
-use crate::{
-    consolidation::{consolidate_demand, consolidate_links},
-    error::{Result, ShapleyError},
-    lp_builder::LpBuilderInput,
-    solver::{SolveStatus, create_coalition_solver},
-    types::{Demands, Devices, PrivateLinks, PublicLinks},
-    utils::factorial,
-    validation::check_inputs,
-};
-use rayon::prelude::*;
 use std::{
+    cell::RefCell,
     collections::{BTreeMap, HashMap},
     fmt::{Display, Formatter},
 };
 
+use rayon::prelude::*;
 #[cfg(feature = "serde")]
 use {
     serde::{Deserialize, Serialize},
     tabled::Tabled,
+};
+
+use crate::{
+    consolidation::{consolidate_demand, consolidate_links},
+    error::{Result, ShapleyError},
+    lp_builder::LpBuilderInput,
+    solver::{CoalitionBuffers, PrecomputedRows, SolveStatus, solve_coalition},
+    types::{Demands, Devices, PrivateLinks, PublicLinks},
+    utils::factorial,
+    validation::check_inputs,
 };
 
 /// Sentinel bit for operators that are always included in every coalition
@@ -154,6 +156,9 @@ impl Shapley {
         // Build LP primitives
         let primitives = LpBuilderInput::new(&full_map, &full_demand).build()?;
 
+        // Pre-compute row-oriented constraint data (once, before the coalition loop)
+        let precomputed = PrecomputedRows::new(&primitives);
+
         // Pre-compute operator bitmasks (once, before the parallel loop)
         let op_index: HashMap<&str, u8> = operators
             .iter()
@@ -193,37 +198,42 @@ impl Shapley {
             .collect();
 
         let n_coalitions = 1 << n_operators;
+        let n_cols = col_op1_mask.len();
+
+        thread_local! {
+            static BUFFERS: RefCell<Option<CoalitionBuffers>> = const { RefCell::new(None) };
+        }
 
         // Solve LP for each coalition
         let coalition_values: Vec<Option<f64>> = (0..n_coalitions)
             .into_par_iter()
             .map(|coalition_idx| {
-                let coalition_mask = (coalition_idx as u32) | ALWAYS_BIT;
+                BUFFERS.with(|cell| {
+                    let mut borrow = cell.borrow_mut();
+                    let buf = borrow.get_or_insert_with(|| CoalitionBuffers::new(n_cols));
 
-                match create_coalition_solver(
-                    &primitives,
-                    coalition_mask,
-                    &col_op1_mask,
-                    &col_op2_mask,
-                    &row_op1_mask,
-                    &row_op2_mask,
-                ) {
-                    Ok(solver) => {
-                        // Solve and return the optimal value
-                        match solver.solve() {
-                            Ok(solution) => {
-                                if matches!(solution.status, SolveStatus::Solved) {
-                                    let value = -solution.objective_value; // Negative because we minimize
-                                    Some(value)
-                                } else {
-                                    None // Infeasible coalition
-                                }
+                    let coalition_mask = (coalition_idx as u32) | ALWAYS_BIT;
+
+                    match solve_coalition(
+                        &primitives,
+                        &precomputed,
+                        buf,
+                        coalition_mask,
+                        &col_op1_mask,
+                        &col_op2_mask,
+                        &row_op1_mask,
+                        &row_op2_mask,
+                    ) {
+                        Ok(result) => {
+                            if matches!(result.status, SolveStatus::Solved) {
+                                Some(-result.objective_value) // Negative because we minimize
+                            } else {
+                                None // Infeasible coalition
                             }
-                            Err(_) => None,
                         }
+                        Err(_) => None,
                     }
-                    Err(_) => None,
-                }
+                })
             })
             .collect();
 

--- a/src/simplex/helpers.rs
+++ b/src/simplex/helpers.rs
@@ -2,6 +2,11 @@ use std::ops::Deref;
 
 use sprs::{CsVecBase, CsVecView};
 
+/// Return a view of a sparse vector truncated to `len` elements.
+///
+/// Any entries whose index is >= `len` are dropped from the view.
+/// This is used when a vector needs to be projected into a smaller
+/// dimension (e.g. after resizing the constraint matrix).
 pub(crate) fn resized_view<IStorage, DStorage>(
     vec: &CsVecBase<IStorage, DStorage, f64>,
     len: usize,
@@ -25,6 +30,7 @@ where
     CsVecView::new(len, indices, data)
 }
 
+/// Convert a sparse vector into a dense `Vec<f64>` (zeros where no entry exists).
 pub(crate) fn to_dense<IStorage, DStorage>(vec: &CsVecBase<IStorage, DStorage, f64>) -> Vec<f64>
 where
     IStorage: Deref<Target = [usize]>,

--- a/src/simplex/helpers.rs
+++ b/src/simplex/helpers.rs
@@ -1,0 +1,36 @@
+use std::ops::Deref;
+
+use sprs::{CsVecBase, CsVecView};
+
+pub(crate) fn resized_view<IStorage, DStorage>(
+    vec: &CsVecBase<IStorage, DStorage, f64>,
+    len: usize,
+) -> CsVecView<'_, f64>
+where
+    IStorage: Deref<Target = [usize]>,
+    DStorage: Deref<Target = [f64]>,
+{
+    let mut indices = vec.indices();
+    let mut data = vec.data();
+    while let Some(&i) = indices.last() {
+        if i < len {
+            // TODO: binary search
+            break;
+        }
+
+        indices = &indices[..(indices.len() - 1)];
+        data = &data[..(data.len() - 1)];
+    }
+
+    CsVecView::new(len, indices, data)
+}
+
+pub(crate) fn to_dense<IStorage, DStorage>(vec: &CsVecBase<IStorage, DStorage, f64>) -> Vec<f64>
+where
+    IStorage: Deref<Target = [usize]>,
+    DStorage: Deref<Target = [f64]>,
+{
+    let mut dense = vec![0.0; vec.dim()];
+    vec.scatter(&mut dense);
+    dense
+}

--- a/src/simplex/lu.rs
+++ b/src/simplex/lu.rs
@@ -1,0 +1,416 @@
+use std::cmp::Ordering;
+
+use super::{
+    solver::EPS,
+    sparse::{Error, Perm, ScatteredVec, SparseMat, TriangleMat},
+};
+
+#[derive(Clone)]
+pub struct LUFactors {
+    lower: TriangleMat,
+    upper: TriangleMat,
+    row_perm: Option<Perm>,
+    col_perm: Option<Perm>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ScratchSpace {
+    rhs: ScatteredVec,
+    dense_rhs: Vec<f64>,
+    mark_nonzero: MarkNonzero,
+}
+
+impl ScratchSpace {
+    pub fn with_capacity(n: usize) -> ScratchSpace {
+        ScratchSpace {
+            rhs: ScatteredVec::empty(n),
+            dense_rhs: vec![0.0; n],
+            mark_nonzero: MarkNonzero::with_capacity(n),
+        }
+    }
+
+    pub(crate) fn clear_sparse(&mut self, size: usize) {
+        self.rhs.clear_and_resize(size);
+        self.mark_nonzero.clear_and_resize(size);
+    }
+}
+
+impl std::fmt::Debug for LUFactors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "L:\n{:?}", self.lower)?;
+        writeln!(f, "U:\n{:?}", self.upper)?;
+        writeln!(
+            f,
+            "row_perm.new2orig: {:?}",
+            self.row_perm.as_ref().map(|p| &p.new2orig)
+        )?;
+        writeln!(
+            f,
+            "col_perm.new2orig: {:?}",
+            self.col_perm.as_ref().map(|p| &p.new2orig)
+        )?;
+        Ok(())
+    }
+}
+
+impl LUFactors {
+    pub fn nnz(&self) -> usize {
+        self.lower.nondiag.nnz() + self.upper.nondiag.nnz() + self.lower.cols()
+    }
+
+    pub fn solve_dense(&self, rhs: &mut [f64], scratch: &mut ScratchSpace) {
+        scratch.dense_rhs.resize(rhs.len(), 0.0);
+
+        if let Some(row_perm) = &self.row_perm {
+            for (i, rhs_el) in rhs.iter().enumerate() {
+                scratch.dense_rhs[row_perm.orig2new[i]] = *rhs_el;
+            }
+        } else {
+            scratch.dense_rhs.copy_from_slice(rhs);
+        }
+
+        tri_solve_dense(&self.lower, Triangle::Lower, &mut scratch.dense_rhs);
+        tri_solve_dense(&self.upper, Triangle::Upper, &mut scratch.dense_rhs);
+
+        if let Some(col_perm) = &self.col_perm {
+            for i in 0..rhs.len() {
+                rhs[col_perm.new2orig[i]] = scratch.dense_rhs[i];
+            }
+        } else {
+            rhs.copy_from_slice(&scratch.dense_rhs);
+        }
+    }
+
+    pub fn solve(&self, rhs: &mut ScatteredVec, scratch: &mut ScratchSpace) {
+        if let Some(row_perm) = &self.row_perm {
+            scratch.rhs.clear();
+            for &i in &rhs.nonzero {
+                let new_i = row_perm.orig2new[i];
+                scratch.rhs.nonzero.push(new_i);
+                scratch.rhs.is_nonzero[new_i] = true;
+                scratch.rhs.values[new_i] = rhs.values[i];
+            }
+        } else {
+            std::mem::swap(&mut scratch.rhs, rhs);
+        }
+
+        tri_solve_sparse(&self.lower, scratch);
+        tri_solve_sparse(&self.upper, scratch);
+
+        if let Some(col_perm) = &self.col_perm {
+            rhs.clear();
+            for &i in &scratch.rhs.nonzero {
+                let new_i = col_perm.new2orig[i];
+                rhs.nonzero.push(new_i);
+                rhs.is_nonzero[new_i] = true;
+                rhs.values[new_i] = scratch.rhs.values[i];
+            }
+        } else {
+            std::mem::swap(rhs, &mut scratch.rhs);
+        }
+    }
+
+    pub fn transpose(&self) -> LUFactors {
+        LUFactors {
+            lower: self.upper.transpose(),
+            upper: self.lower.transpose(),
+            row_perm: self.col_perm.clone(),
+            col_perm: self.row_perm.clone(),
+        }
+    }
+}
+
+pub fn lu_factorize<'a>(
+    size: usize,
+    get_col: impl Fn(usize) -> (&'a [usize], &'a [f64]),
+    stability_coeff: f64,
+    scratch: &mut ScratchSpace,
+) -> Result<LUFactors, Error> {
+    let col_perm = super::ordering::order_simple(size, |c| get_col(c).0);
+
+    let mut orig_row2elt_count = vec![0; size];
+    for col_rows in (0..size).map(|c| get_col(c).0) {
+        for &orig_r in col_rows {
+            orig_row2elt_count[orig_r] += 1;
+        }
+    }
+
+    scratch.clear_sparse(size);
+
+    let mut lower = SparseMat::new(size);
+    let mut upper = SparseMat::new(size);
+    let mut upper_diag = Vec::with_capacity(size);
+
+    let mut new2orig_row = (0..size).collect::<Vec<_>>();
+    let mut orig2new_row = new2orig_row.clone();
+
+    for i_col in 0..size {
+        let mat_col = get_col(col_perm.new2orig[i_col]);
+
+        scratch.rhs.set(mat_col.0.iter().copied().zip(mat_col.1));
+
+        scratch.mark_nonzero.run(
+            &mut scratch.rhs,
+            |new_i| lower.col_rows(new_i),
+            |new_i| new_i < i_col,
+            |orig_r| orig2new_row[orig_r],
+        );
+
+        for &orig_i in scratch.mark_nonzero.visited.iter().rev() {
+            let new_i = orig2new_row[orig_i];
+            if new_i < i_col {
+                let x_val = scratch.rhs.values[orig_i];
+                for (orig_r, coeff) in lower.col_iter(new_i) {
+                    scratch.rhs.values[orig_r] -= x_val * coeff;
+                }
+            }
+        }
+
+        let pivot_orig_r = {
+            let mut max_abs = 0.0;
+            for &orig_r in &scratch.rhs.nonzero {
+                if orig2new_row[orig_r] < i_col {
+                    continue;
+                }
+
+                let abs = f64::abs(scratch.rhs.values[orig_r]);
+                if abs > max_abs {
+                    max_abs = abs;
+                }
+            }
+
+            if max_abs < EPS {
+                return Err(Error::SingularMatrix);
+            }
+
+            assert!(max_abs.is_normal());
+
+            let mut best_orig_r = None;
+            let mut best_elt_count = None;
+            for &orig_r in &scratch.rhs.nonzero {
+                if orig2new_row[orig_r] < i_col {
+                    continue;
+                }
+
+                if f64::abs(scratch.rhs.values[orig_r]) >= stability_coeff * max_abs {
+                    let elt_count = orig_row2elt_count[orig_r];
+                    if best_elt_count.is_none() || best_elt_count.unwrap() > elt_count {
+                        best_orig_r = Some(orig_r);
+                        best_elt_count = Some(elt_count);
+                    }
+                }
+            }
+            best_orig_r.unwrap()
+        };
+
+        let pivot_val = scratch.rhs.values[pivot_orig_r];
+
+        {
+            let row = i_col;
+            let orig_row = new2orig_row[row];
+            let pivot_row = orig2new_row[pivot_orig_r];
+            new2orig_row.swap(row, pivot_row);
+            orig2new_row.swap(orig_row, pivot_orig_r);
+        }
+
+        for &orig_r in &scratch.rhs.nonzero {
+            let val = scratch.rhs.values[orig_r];
+
+            if val == 0.0 {
+                continue;
+            }
+
+            let new_r = orig2new_row[orig_r];
+            match new_r.cmp(&i_col) {
+                Ordering::Less => upper.push(new_r, val),
+                Ordering::Equal => upper_diag.push(pivot_val),
+                Ordering::Greater => lower.push(orig_r, val / pivot_val),
+            }
+        }
+
+        upper.seal_column();
+        lower.seal_column();
+    }
+
+    // permute rows of lower to "new" indices.
+    for i_col in 0..lower.cols() {
+        for r in lower.col_rows_mut(i_col) {
+            *r = orig2new_row[*r];
+        }
+    }
+
+    let res = LUFactors {
+        lower: TriangleMat {
+            nondiag: lower,
+            diag: None,
+        },
+        upper: TriangleMat {
+            nondiag: upper,
+            diag: Some(upper_diag),
+        },
+        row_perm: Some(Perm {
+            orig2new: orig2new_row,
+            new2orig: new2orig_row,
+        }),
+        col_perm: Some(col_perm),
+    };
+
+    Ok(res)
+}
+
+#[derive(Clone, Debug)]
+struct MarkNonzero {
+    dfs_stack: Vec<DfsStep>,
+    is_visited: Vec<bool>,
+    visited: Vec<usize>, // in reverse topological order
+}
+
+#[derive(Clone, Debug)]
+struct DfsStep {
+    orig_i: usize,
+    cur_child: usize,
+}
+
+impl MarkNonzero {
+    fn with_capacity(n: usize) -> MarkNonzero {
+        MarkNonzero {
+            dfs_stack: Vec::with_capacity(n),
+            is_visited: vec![false; n],
+            visited: vec![],
+        }
+    }
+
+    fn clear(&mut self) {
+        assert!(self.dfs_stack.is_empty());
+        for &i in &self.visited {
+            self.is_visited[i] = false;
+        }
+        self.visited.clear();
+    }
+
+    fn clear_and_resize(&mut self, n: usize) {
+        self.clear();
+        self.dfs_stack.reserve(n);
+        self.is_visited.resize(n, false);
+    }
+
+    // compute the non-zero elements of the result by dfs traversal
+    fn run<'a>(
+        &mut self,
+        rhs: &mut ScatteredVec,
+        get_children: impl Fn(usize) -> &'a [usize] + 'a,
+        filter: impl Fn(usize) -> bool,
+        orig2new_row: impl Fn(usize) -> usize,
+    ) {
+        self.clear();
+
+        for &orig_r in &rhs.nonzero {
+            let new_r = orig2new_row(orig_r);
+            if !filter(new_r) {
+                continue;
+            }
+            if self.is_visited[orig_r] {
+                continue;
+            }
+
+            self.dfs_stack.push(DfsStep {
+                orig_i: orig_r,
+                cur_child: 0,
+            });
+            while !self.dfs_stack.is_empty() {
+                let cur_step = self.dfs_stack.last_mut().unwrap();
+                let new_i = orig2new_row(cur_step.orig_i);
+                let children = if filter(new_i) {
+                    get_children(new_i)
+                } else {
+                    &[]
+                };
+                if !self.is_visited[cur_step.orig_i] {
+                    self.is_visited[cur_step.orig_i] = true;
+                } else {
+                    cur_step.cur_child += 1;
+                }
+
+                while cur_step.cur_child < children.len() {
+                    let child_orig_r = children[cur_step.cur_child];
+                    if !self.is_visited[child_orig_r] {
+                        break;
+                    }
+                    cur_step.cur_child += 1;
+                }
+
+                if cur_step.cur_child < children.len() {
+                    let i_child = cur_step.cur_child;
+                    self.dfs_stack.push(DfsStep {
+                        orig_i: children[i_child],
+                        cur_child: 0,
+                    });
+                } else {
+                    self.visited.push(cur_step.orig_i);
+                    self.dfs_stack.pop();
+                }
+            }
+        }
+
+        for &i in &self.visited {
+            if !rhs.is_nonzero[i] {
+                rhs.is_nonzero[i] = true;
+                rhs.nonzero.push(i)
+            }
+        }
+    }
+}
+
+enum Triangle {
+    Lower,
+    Upper,
+}
+
+fn tri_solve_dense(tri_mat: &TriangleMat, triangle: Triangle, rhs: &mut [f64]) {
+    assert_eq!(tri_mat.rows(), rhs.len());
+    match triangle {
+        Triangle::Lower => {
+            for col in 0..tri_mat.cols() {
+                tri_solve_process_col(tri_mat, col, rhs);
+            }
+        }
+
+        Triangle::Upper => {
+            for col in (0..tri_mat.cols()).rev() {
+                tri_solve_process_col(tri_mat, col, rhs);
+            }
+        }
+    };
+}
+
+/// rhs is passed via scratch.visited, scratch.values.
+fn tri_solve_sparse(tri_mat: &TriangleMat, scratch: &mut ScratchSpace) {
+    assert_eq!(tri_mat.rows(), scratch.rhs.len());
+
+    // compute the non-zero elements of the result by dfs traversal
+    scratch.mark_nonzero.run(
+        &mut scratch.rhs,
+        |col| tri_mat.nondiag.col_rows(col),
+        |_| true,
+        |orig_i| orig_i,
+    );
+
+    // solve for the non-zero values into dense workspace.
+    // rev() because DFS returns vertices in reverse topological order.
+    for &col in scratch.mark_nonzero.visited.iter().rev() {
+        tri_solve_process_col(tri_mat, col, &mut scratch.rhs.values);
+    }
+}
+
+fn tri_solve_process_col(tri_mat: &TriangleMat, col: usize, rhs: &mut [f64]) {
+    let x_val = if let Some(diag) = tri_mat.diag.as_ref() {
+        rhs[col] / diag[col]
+    } else {
+        rhs[col]
+    };
+
+    rhs[col] = x_val;
+    for (r, &coeff) in tri_mat.nondiag.col_iter(col) {
+        rhs[r] -= x_val * coeff;
+    }
+}

--- a/src/simplex/lu.rs
+++ b/src/simplex/lu.rs
@@ -5,14 +5,25 @@ use super::{
     sparse::{Error, Perm, ScatteredVec, SparseMat, TriangleMat},
 };
 
+/// LU decomposition of a square matrix: `P_row * A * P_col = L * U`.
+///
+/// The basis matrix (the columns of the constraint matrix corresponding to
+/// the current basic variables) is factored into lower-triangular `L` and
+/// upper-triangular `U`, with optional row and column permutations for
+/// numerical stability and sparsity. This factorisation is the core of
+/// the simplex method — every pivot requires solving linear systems
+/// `B * x = b`, which becomes `L * U * x = P * b`.
 #[derive(Clone)]
 pub struct LUFactors {
     lower: TriangleMat,
     upper: TriangleMat,
+    /// Row permutation applied before the LU solve (for pivot stability).
     row_perm: Option<Perm>,
+    /// Column permutation applied after the LU solve (for sparsity).
     col_perm: Option<Perm>,
 }
 
+/// Pre-allocated working buffers reused across LU solves to avoid repeated allocation.
 #[derive(Clone, Debug)]
 pub struct ScratchSpace {
     rhs: ScatteredVec,
@@ -58,6 +69,8 @@ impl LUFactors {
         self.lower.nondiag.nnz() + self.upper.nondiag.nnz() + self.lower.cols()
     }
 
+    /// Solve `A * x = rhs` for `x`, overwriting `rhs` with the solution.
+    /// Uses the dense path (forward-substitute through L, back-substitute through U).
     pub fn solve_dense(&self, rhs: &mut [f64], scratch: &mut ScratchSpace) {
         scratch.dense_rhs.resize(rhs.len(), 0.0);
 
@@ -81,6 +94,8 @@ impl LUFactors {
         }
     }
 
+    /// Solve `A * x = rhs` for `x`, overwriting `rhs` with the solution.
+    /// Uses the sparse path — only touches non-zero entries for efficiency.
     pub fn solve(&self, rhs: &mut ScatteredVec, scratch: &mut ScratchSpace) {
         if let Some(row_perm) = &self.row_perm {
             scratch.rhs.clear();
@@ -120,6 +135,14 @@ impl LUFactors {
     }
 }
 
+/// Compute the LU factorisation of a square matrix given column-wise access.
+///
+/// `get_col(c)` returns `(row_indices, values)` for column `c`.
+/// `stability_coeff` controls the threshold for partial pivoting — a pivot
+/// candidate must be at least `stability_coeff * max_abs` to be eligible,
+/// which trades fill-in for numerical accuracy (0.1 is a typical value).
+///
+/// Returns `Err(SingularMatrix)` if the matrix is (numerically) singular.
 pub fn lu_factorize<'a>(
     size: usize,
     get_col: impl Fn(usize) -> (&'a [usize], &'a [f64]),
@@ -258,11 +281,19 @@ pub fn lu_factorize<'a>(
     Ok(res)
 }
 
+/// Determines which entries in the solution will be non-zero *before*
+/// doing the actual arithmetic, by running a depth-first search on
+/// the dependency graph of the triangular matrix.
+///
+/// This is a standard optimisation for sparse triangular solves — by
+/// knowing the non-zero pattern up front, we only compute values we
+/// actually need.
 #[derive(Clone, Debug)]
 struct MarkNonzero {
     dfs_stack: Vec<DfsStep>,
     is_visited: Vec<bool>,
-    visited: Vec<usize>, // in reverse topological order
+    /// Indices in reverse topological order (the order we need to process them).
+    visited: Vec<usize>,
 }
 
 #[derive(Clone, Debug)]
@@ -361,11 +392,14 @@ impl MarkNonzero {
     }
 }
 
+/// Which triangle of the matrix we're solving against.
 enum Triangle {
     Lower,
     Upper,
 }
 
+/// Triangular solve against a dense right-hand side.
+/// Lower: forward substitution (columns 0..n). Upper: back substitution (columns n..0).
 fn tri_solve_dense(tri_mat: &TriangleMat, triangle: Triangle, rhs: &mut [f64]) {
     assert_eq!(tri_mat.rows(), rhs.len());
     match triangle {
@@ -402,6 +436,8 @@ fn tri_solve_sparse(tri_mat: &TriangleMat, scratch: &mut ScratchSpace) {
     }
 }
 
+/// Process one column during triangular substitution: divide by the diagonal
+/// (if present), then subtract contributions from all off-diagonal entries.
 fn tri_solve_process_col(tri_mat: &TriangleMat, col: usize, rhs: &mut [f64]) {
     let x_val = if let Some(diag) = tri_mat.diag.as_ref() {
         rhs[col] / diag[col]

--- a/src/simplex/mod.rs
+++ b/src/simplex/mod.rs
@@ -1,7 +1,24 @@
 //! Vendored solver internals from microlp v0.4.0.
 //!
-//! This module provides direct access to the simplex Solver, bypassing
+//! This module provides direct access to the simplex [`solver::Solver`], bypassing
 //! microlp's `Problem` builder API to avoid per-constraint CsVec allocations.
+//!
+//! ## How the pieces fit together
+//!
+//! ```text
+//! shapley.rs  ──▶  solver.rs (solve_coalition)
+//!                       │
+//!                       ▼
+//!               simplex::solver::Solver   ← the LP engine
+//!                   ├── simplex::lu        ← LU factorisation of the basis matrix
+//!                   ├── simplex::sparse    ← sparse vector / matrix types used internally
+//!                   ├── simplex::ordering  ← column pre-ordering heuristic for LU
+//!                   └── simplex::helpers   ← small sparse-vector utilities
+//! ```
+//!
+//! The `#[allow(dead_code)]` annotations exist because this is a vendored library
+//! with internal infrastructure that isn't all reachable from our public API, but
+//! is required for the solver's correctness.
 
 #[allow(dead_code, clippy::all)]
 pub(crate) mod helpers;

--- a/src/simplex/mod.rs
+++ b/src/simplex/mod.rs
@@ -1,0 +1,15 @@
+//! Vendored solver internals from microlp v0.4.0.
+//!
+//! This module provides direct access to the simplex Solver, bypassing
+//! microlp's `Problem` builder API to avoid per-constraint CsVec allocations.
+
+#[allow(dead_code, clippy::all)]
+pub(crate) mod helpers;
+#[allow(dead_code, clippy::all)]
+pub(crate) mod lu;
+#[allow(dead_code, clippy::all)]
+pub(crate) mod ordering;
+#[allow(dead_code, clippy::all)]
+pub(crate) mod solver;
+#[allow(dead_code, clippy::all)]
+pub(crate) mod sparse;

--- a/src/simplex/ordering.rs
+++ b/src/simplex/ordering.rs
@@ -1,0 +1,97 @@
+use super::sparse::Perm;
+
+/// Simplest preordering: order columns based on their size
+pub fn order_simple<'a>(size: usize, get_col: impl Fn(usize) -> &'a [usize]) -> Perm {
+    let mut cols_queue = ColsQueue::new(size);
+    for c in 0..size {
+        cols_queue.add(c, get_col(c).len() - 1);
+    }
+
+    let mut new2orig = Vec::with_capacity(size);
+
+    //TODO should this be refactored?
+    while new2orig.len() < size {
+        let min = cols_queue.pop_min();
+        //guaranteed to exist
+        new2orig.push(min.unwrap());
+    }
+
+    let mut orig2new = vec![0; size];
+    for (new, &orig) in new2orig.iter().enumerate() {
+        orig2new[orig] = new;
+    }
+
+    Perm { orig2new, new2orig }
+}
+
+#[derive(Debug)]
+struct ColsQueue {
+    score2head: Vec<Option<usize>>,
+    prev: Vec<usize>,
+    next: Vec<usize>,
+    min_score: usize,
+    len: usize,
+}
+
+impl ColsQueue {
+    fn new(num_cols: usize) -> ColsQueue {
+        ColsQueue {
+            score2head: vec![None; num_cols],
+            prev: vec![0; num_cols],
+            next: vec![0; num_cols],
+            min_score: num_cols,
+            len: 0,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn pop_min(&mut self) -> Option<usize> {
+        let col = loop {
+            if self.min_score >= self.score2head.len() {
+                return None;
+            }
+            if let Some(col) = self.score2head[self.min_score] {
+                break col;
+            }
+            self.min_score += 1;
+        };
+
+        self.remove(col, self.min_score);
+        Some(col)
+    }
+
+    fn add(&mut self, col: usize, score: usize) {
+        self.min_score = std::cmp::min(self.min_score, score);
+        self.len += 1;
+
+        if let Some(head) = self.score2head[score] {
+            self.prev[col] = self.prev[head];
+            self.next[col] = head;
+            self.next[self.prev[head]] = col;
+            self.prev[head] = col;
+        } else {
+            self.prev[col] = col;
+            self.next[col] = col;
+            self.score2head[score] = Some(col);
+        }
+    }
+
+    fn remove(&mut self, col: usize, score: usize) {
+        self.len -= 1;
+        if self.next[col] == col {
+            self.score2head[score] = None;
+        } else {
+            self.next[self.prev[col]] = self.next[col];
+            self.prev[self.next[col]] = self.prev[col];
+
+            //will panic if score is not valid
+            if self.score2head[score].unwrap() == col {
+                self.score2head[score] = Some(self.next[col]);
+            }
+        }
+    }
+}

--- a/src/simplex/ordering.rs
+++ b/src/simplex/ordering.rs
@@ -1,6 +1,10 @@
 use super::sparse::Perm;
 
-/// Simplest preordering: order columns based on their size
+/// Pre-order columns by ascending number of non-zeros (sparsest first).
+///
+/// This heuristic reduces fill-in during LU factorisation — processing
+/// sparser columns first tends to produce sparser L and U factors.
+/// Returns a [`Perm`] mapping between original and reordered column indices.
 pub fn order_simple<'a>(size: usize, get_col: impl Fn(usize) -> &'a [usize]) -> Perm {
     let mut cols_queue = ColsQueue::new(size);
     for c in 0..size {
@@ -24,11 +28,20 @@ pub fn order_simple<'a>(size: usize, get_col: impl Fn(usize) -> &'a [usize]) -> 
     Perm { orig2new, new2orig }
 }
 
+/// A priority queue of columns keyed by their "score" (non-zero count).
+///
+/// Implemented as an array of circular doubly-linked lists — one list per
+/// score value. `pop_min()` returns the column with the smallest score,
+/// which is the sparsest column. This is efficient because scores are
+/// small non-negative integers bounded by the matrix dimension.
 #[derive(Debug)]
 struct ColsQueue {
+    /// Head pointer for each score bucket (None = empty bucket).
     score2head: Vec<Option<usize>>,
+    /// Prev/next pointers forming circular doubly-linked lists within each bucket.
     prev: Vec<usize>,
     next: Vec<usize>,
+    /// Smallest score that has any columns in it (avoids scanning empty buckets).
     min_score: usize,
     len: usize,
 }

--- a/src/simplex/solver.rs
+++ b/src/simplex/solver.rs
@@ -1,0 +1,1504 @@
+// Vendored from microlp v0.4.0 — stripped of integer solving (solve_integer, branch-and-bound).
+
+use microlp::{ComparisonOp, Error, StopReason, VarDomain};
+use sprs::CompressedStorage;
+use web_time::Instant;
+
+use super::{
+    helpers::{resized_view, to_dense},
+    lu::{LUFactors, ScratchSpace, lu_factorize},
+    sparse::{ScatteredVec, SparseMat, SparseVec},
+};
+
+pub(crate) type CsVec = sprs::CsVecI<f64, usize>;
+pub(crate) type Deadline = Option<Instant>;
+
+type CsMat = sprs::CsMatI<f64, usize>;
+
+pub(crate) const MACHINE_EPS: f64 = f64::EPSILON * 10.0;
+pub const EPS: f64 = if MACHINE_EPS > 1e-8 {
+    MACHINE_EPS
+} else {
+    1e-10
+};
+
+pub(crate) fn float_eq(a: f64, b: f64) -> bool {
+    (a - b).abs() < EPS
+}
+pub(crate) fn float_ne(a: f64, b: f64) -> bool {
+    !float_eq(a, b)
+}
+
+#[inline]
+fn check_deadline(deadline: &Deadline) -> StopReason {
+    if let Some(dl) = deadline {
+        if Instant::now() >= *dl {
+            return StopReason::Limit;
+        }
+    }
+    StopReason::Finished
+}
+
+#[derive(Clone)]
+pub(crate) struct Solver {
+    pub(crate) num_vars: usize,
+    pub(crate) deadline: Deadline,
+
+    orig_obj_coeffs: Vec<f64>,
+    orig_var_mins: Vec<f64>,
+    orig_var_maxs: Vec<f64>,
+    pub(crate) orig_var_domains: Vec<VarDomain>,
+    orig_constraints: CsMat, // excluding rhs
+    orig_constraints_csc: CsMat,
+    orig_rhs: Vec<f64>,
+
+    enable_primal_steepest_edge: bool,
+    enable_dual_steepest_edge: bool,
+
+    is_primal_feasible: bool,
+    is_dual_feasible: bool,
+
+    // Updated on each pivot
+    /// For each var: whether it is basic/non-basic and the corresponding index.
+    var_states: Vec<VarState>,
+    basis_solver: BasisSolver,
+
+    /// For each constraint the corresponding basic var.
+    basic_vars: Vec<usize>,
+    basic_var_vals: Vec<f64>,
+    basic_var_mins: Vec<f64>,
+    basic_var_maxs: Vec<f64>,
+    dual_edge_sq_norms: Vec<f64>,
+
+    /// Remaining variables. (idx -> var), 'nb' means 'non-basic'
+    nb_vars: Vec<usize>,
+    nb_var_obj_coeffs: Vec<f64>,
+    nb_var_vals: Vec<f64>,
+    nb_var_states: Vec<NonBasicVarState>,
+    nb_var_is_fixed: Vec<bool>,
+    primal_edge_sq_norms: Vec<f64>,
+
+    pub(crate) cur_obj_val: f64,
+
+    // Recomputed on each pivot
+    col_coeffs: SparseVec,
+    sq_norms_update_helper: Vec<f64>,
+    inv_basis_row_coeffs: SparseVec,
+    row_coeffs: ScatteredVec,
+}
+
+#[derive(Clone, Debug)]
+enum VarState {
+    Basic(usize),
+    NonBasic(usize),
+}
+
+#[derive(Clone, Debug)]
+struct NonBasicVarState {
+    at_min: bool,
+    at_max: bool,
+}
+
+impl std::fmt::Debug for Solver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Solver")?;
+        writeln!(
+            f,
+            "num_vars: {}, num_constraints: {}, is_primal_feasible: {}, is_dual_feasible: {}",
+            self.num_vars,
+            self.num_constraints(),
+            self.is_primal_feasible,
+            self.is_dual_feasible,
+        )?;
+        writeln!(f, "orig_obj_coeffs:\n{:?}", self.orig_obj_coeffs)?;
+        writeln!(f, "orig_var_mins:\n{:?}", self.orig_var_mins)?;
+        writeln!(f, "orig_var_maxs:\n{:?}", self.orig_var_maxs)?;
+        writeln!(f, "orig_constraints:")?;
+        for row in self.orig_constraints.outer_iterator() {
+            writeln!(f, "{:?}", to_dense(&row))?;
+        }
+        writeln!(f, "orig_rhs:\n{:?}", self.orig_rhs)?;
+        writeln!(f, "basic_vars:\n{:?}", self.basic_vars)?;
+        writeln!(f, "basic_var_vals:\n{:?}", self.basic_var_vals)?;
+        writeln!(f, "dual_edge_sq_norms:\n{:?}", self.dual_edge_sq_norms)?;
+        writeln!(f, "nb_vars:\n{:?}", self.nb_vars)?;
+        writeln!(f, "nb_var_vals:\n{:?}", self.nb_var_vals)?;
+        writeln!(f, "nb_var_obj_coeffs:\n{:?}", self.nb_var_obj_coeffs)?;
+        writeln!(f, "primal_edge_sq_norms:\n{:?}", self.primal_edge_sq_norms)?;
+        writeln!(f, "cur_obj_val: {:?}", self.cur_obj_val)?;
+        Ok(())
+    }
+}
+
+impl Solver {
+    pub(crate) fn try_new(
+        obj_coeffs: &[f64],
+        var_mins: &[f64],
+        var_maxs: &[f64],
+        constraints: &[(CsVec, ComparisonOp, f64)],
+        var_domains: &[VarDomain],
+        deadline: Deadline,
+    ) -> Result<Self, Error> {
+        let enable_steepest_edge = true;
+
+        let num_vars = obj_coeffs.len();
+
+        assert_eq!(num_vars, var_mins.len());
+        assert_eq!(num_vars, var_maxs.len());
+        let mut orig_var_mins = var_mins.to_vec();
+        let mut orig_var_maxs = var_maxs.to_vec();
+
+        let mut var_states = vec![];
+
+        let mut nb_vars = vec![];
+        let mut nb_var_vals = vec![];
+        let mut nb_var_states = vec![];
+
+        let mut obj_val = 0.0;
+
+        let mut is_dual_feasible = true;
+
+        for v in 0..num_vars {
+            let min = orig_var_mins[v];
+            let max = orig_var_maxs[v];
+            if min > max {
+                return Err(Error::Infeasible);
+            }
+
+            var_states.push(VarState::NonBasic(nb_vars.len()));
+            nb_vars.push(v);
+
+            let init_val = if float_eq(min, max) {
+                min
+            } else if min.is_infinite() && max.is_infinite() {
+                if float_ne(obj_coeffs[v], 0.0) {
+                    is_dual_feasible = false;
+                }
+                0.0
+            } else if obj_coeffs[v] > 0.0 {
+                if min.is_finite() {
+                    min
+                } else {
+                    is_dual_feasible = false;
+                    max
+                }
+            } else if obj_coeffs[v] < 0.0 {
+                if max.is_finite() {
+                    max
+                } else {
+                    is_dual_feasible = false;
+                    min
+                }
+            } else if min.is_finite() {
+                min
+            } else {
+                max
+            };
+
+            nb_var_vals.push(init_val);
+            obj_val += init_val * obj_coeffs[v];
+
+            nb_var_states.push(NonBasicVarState {
+                at_min: float_eq(init_val, min),
+                at_max: float_eq(init_val, max),
+            });
+        }
+
+        let mut constraint_coeffs = vec![];
+        let mut orig_rhs = vec![];
+
+        let mut basic_vars = vec![];
+        let mut basic_var_vals = vec![];
+        let mut basic_var_mins = vec![];
+        let mut basic_var_maxs = vec![];
+
+        for (coeffs, cmp_op, rhs) in constraints {
+            let rhs = *rhs;
+
+            if coeffs.indices().is_empty() {
+                let is_tautological = match cmp_op {
+                    ComparisonOp::Eq => float_eq(rhs, 0.0),
+                    ComparisonOp::Le => 0.0 <= rhs,
+                    ComparisonOp::Ge => 0.0 >= rhs,
+                };
+
+                if is_tautological {
+                    continue;
+                } else {
+                    return Err(Error::Infeasible);
+                }
+            }
+
+            constraint_coeffs.push(coeffs.clone());
+            orig_rhs.push(rhs);
+
+            let (slack_var_min, slack_var_max) = match cmp_op {
+                ComparisonOp::Le => (0.0, f64::INFINITY),
+                ComparisonOp::Ge => (f64::NEG_INFINITY, 0.0),
+                ComparisonOp::Eq => (0.0, 0.0),
+            };
+
+            orig_var_mins.push(slack_var_min);
+            orig_var_maxs.push(slack_var_max);
+
+            basic_var_mins.push(slack_var_min);
+            basic_var_maxs.push(slack_var_max);
+
+            let cur_slack_var = var_states.len();
+            var_states.push(VarState::Basic(basic_vars.len()));
+            basic_vars.push(cur_slack_var);
+
+            let mut lhs_val = 0.0;
+            for (var, &coeff) in coeffs.iter() {
+                lhs_val += coeff * nb_var_vals[var];
+            }
+            basic_var_vals.push(rhs - lhs_val);
+        }
+
+        let num_constraints = constraint_coeffs.len();
+        let num_total_vars = num_vars + num_constraints;
+
+        let mut orig_obj_coeffs = obj_coeffs.to_vec();
+        orig_obj_coeffs.resize(num_total_vars, 0.0);
+
+        let mut orig_constraints = CsMat::empty(CompressedStorage::CSR, num_total_vars);
+        for (cur_slack_var, coeffs) in constraint_coeffs.into_iter().enumerate() {
+            let mut coeffs = into_resized(coeffs, num_total_vars);
+            coeffs.append(num_vars + cur_slack_var, 1.0);
+            orig_constraints = orig_constraints.append_outer_csvec(coeffs.view());
+        }
+        let orig_constraints_csc = orig_constraints.to_csc();
+
+        let is_primal_feasible = basic_var_vals
+            .iter()
+            .zip(&basic_var_mins)
+            .zip(&basic_var_maxs)
+            .all(|((&val, &min), &max)| val >= min && val <= max);
+
+        let need_artificial_obj = !is_primal_feasible && !is_dual_feasible;
+
+        let enable_dual_steepest_edge = enable_steepest_edge;
+        let dual_edge_sq_norms = if enable_dual_steepest_edge {
+            vec![1.0; basic_vars.len()]
+        } else {
+            vec![]
+        };
+
+        let enable_primal_steepest_edge = enable_steepest_edge && !is_dual_feasible;
+        let sq_norms_update_helper = if enable_primal_steepest_edge {
+            vec![0.0; num_total_vars - num_constraints]
+        } else {
+            vec![]
+        };
+
+        let mut nb_var_obj_coeffs = vec![];
+        let mut primal_edge_sq_norms = vec![];
+        for (&var, state) in nb_vars.iter().zip(&nb_var_states) {
+            let col = orig_constraints_csc.outer_view(var).unwrap();
+
+            if need_artificial_obj {
+                let coeff = if state.at_min && !state.at_max {
+                    1.0
+                } else if state.at_max && !state.at_min {
+                    -1.0
+                } else {
+                    0.0
+                };
+                nb_var_obj_coeffs.push(coeff);
+            } else {
+                nb_var_obj_coeffs.push(orig_obj_coeffs[var]);
+            }
+
+            if enable_primal_steepest_edge {
+                primal_edge_sq_norms.push(col.squared_l2_norm() + 1.0);
+            }
+        }
+
+        let cur_obj_val = if need_artificial_obj { 0.0 } else { obj_val };
+
+        let mut scratch = ScratchSpace::with_capacity(num_constraints);
+        let lu_factors = lu_factorize(
+            basic_vars.len(),
+            |c| {
+                orig_constraints_csc
+                    .outer_view(basic_vars[c])
+                    .unwrap()
+                    .into_raw_storage()
+            },
+            0.1,
+            &mut scratch,
+        )
+        .map_err(|e| Error::InternalError(e.to_string()))?;
+        let lu_factors_transp = lu_factors.transpose();
+
+        let nb_var_is_fixed = vec![false; nb_vars.len()];
+
+        let res = Self {
+            num_vars,
+            orig_obj_coeffs,
+            orig_var_mins,
+            orig_var_maxs,
+            orig_constraints,
+            orig_constraints_csc,
+            orig_rhs,
+            deadline,
+            orig_var_domains: var_domains.to_vec(),
+            enable_primal_steepest_edge,
+            enable_dual_steepest_edge,
+            is_primal_feasible,
+            is_dual_feasible,
+            var_states,
+            basis_solver: BasisSolver {
+                lu_factors,
+                lu_factors_transp,
+                scratch,
+                eta_matrices: EtaMatrices::new(num_constraints),
+                rhs: ScatteredVec::empty(num_constraints),
+            },
+            basic_vars,
+            basic_var_vals,
+            basic_var_mins,
+            basic_var_maxs,
+            dual_edge_sq_norms,
+            nb_vars,
+            nb_var_obj_coeffs,
+            nb_var_vals,
+            nb_var_states,
+            nb_var_is_fixed,
+            primal_edge_sq_norms,
+            cur_obj_val,
+            col_coeffs: SparseVec::new(),
+            sq_norms_update_helper,
+            inv_basis_row_coeffs: SparseVec::new(),
+            row_coeffs: ScatteredVec::empty(num_total_vars - num_constraints),
+        };
+
+        Ok(res)
+    }
+
+    /// Like `try_new`, but accepts a pre-built CSR constraint matrix instead of
+    /// individual `CsVec` rows.  This avoids ~N per-row `CsVec` allocations
+    /// when the caller can build the matrix in bulk (e.g. via `TriMatI`).
+    ///
+    /// `constraint_matrix_csr` must be `(num_constraints × num_vars)` in CSR
+    /// storage.  `constraint_ops` and `constraint_rhs` must have length
+    /// `num_constraints` and correspond row-by-row to the matrix.
+    pub(crate) fn try_new_from_matrix(
+        obj_coeffs: &[f64],
+        var_mins: &[f64],
+        var_maxs: &[f64],
+        constraint_matrix_csr: CsMat, // (num_constraints × num_vars), CSR
+        constraint_ops: &[ComparisonOp],
+        constraint_rhs: &[f64],
+        var_domains: &[VarDomain],
+        deadline: Deadline,
+    ) -> Result<Self, Error> {
+        let enable_steepest_edge = true;
+
+        let num_vars = obj_coeffs.len();
+        assert_eq!(num_vars, var_mins.len());
+        assert_eq!(num_vars, var_maxs.len());
+        assert_eq!(constraint_ops.len(), constraint_rhs.len());
+
+        let mut orig_var_mins = var_mins.to_vec();
+        let mut orig_var_maxs = var_maxs.to_vec();
+
+        let mut var_states = vec![];
+        let mut nb_vars = vec![];
+        let mut nb_var_vals = vec![];
+        let mut nb_var_states = vec![];
+        let mut obj_val = 0.0;
+        let mut is_dual_feasible = true;
+
+        // --- variable initialisation (identical to try_new) ---
+        for v in 0..num_vars {
+            let min = orig_var_mins[v];
+            let max = orig_var_maxs[v];
+            if min > max {
+                return Err(Error::Infeasible);
+            }
+
+            var_states.push(VarState::NonBasic(nb_vars.len()));
+            nb_vars.push(v);
+
+            let init_val = if float_eq(min, max) {
+                min
+            } else if min.is_infinite() && max.is_infinite() {
+                if float_ne(obj_coeffs[v], 0.0) {
+                    is_dual_feasible = false;
+                }
+                0.0
+            } else if obj_coeffs[v] > 0.0 {
+                if min.is_finite() {
+                    min
+                } else {
+                    is_dual_feasible = false;
+                    max
+                }
+            } else if obj_coeffs[v] < 0.0 {
+                if max.is_finite() {
+                    max
+                } else {
+                    is_dual_feasible = false;
+                    min
+                }
+            } else if min.is_finite() {
+                min
+            } else {
+                max
+            };
+
+            nb_var_vals.push(init_val);
+            obj_val += init_val * obj_coeffs[v];
+
+            nb_var_states.push(NonBasicVarState {
+                at_min: float_eq(init_val, min),
+                at_max: float_eq(init_val, max),
+            });
+        }
+
+        // --- process constraints from the CSR matrix ---
+        // We need to handle empty rows exactly as try_new does: skip tautological
+        // ones and error on infeasible ones.  Non-empty rows become actual
+        // constraints with slack variables.
+
+        let input_rows = constraint_matrix_csr.rows();
+
+        // First pass: determine which rows survive (non-empty)
+        let mut kept_row_indices: Vec<usize> = Vec::with_capacity(input_rows);
+        for i in 0..input_rows {
+            let row_view = constraint_matrix_csr.outer_view(i).unwrap();
+            if row_view.nnz() == 0 {
+                let rhs = constraint_rhs[i];
+                let is_tautological = match constraint_ops[i] {
+                    ComparisonOp::Eq => float_eq(rhs, 0.0),
+                    ComparisonOp::Le => 0.0 <= rhs,
+                    ComparisonOp::Ge => 0.0 >= rhs,
+                };
+                if !is_tautological {
+                    return Err(Error::Infeasible);
+                }
+                // tautological — skip
+            } else {
+                kept_row_indices.push(i);
+            }
+        }
+
+        let num_constraints = kept_row_indices.len();
+        let num_total_vars = num_vars + num_constraints;
+
+        let mut orig_rhs = Vec::with_capacity(num_constraints);
+        let mut basic_vars = Vec::with_capacity(num_constraints);
+        let mut basic_var_vals = Vec::with_capacity(num_constraints);
+        let mut basic_var_mins = Vec::with_capacity(num_constraints);
+        let mut basic_var_maxs = Vec::with_capacity(num_constraints);
+
+        // Build the augmented CSR matrix (original cols + slack identity cols)
+        // from the input matrix's raw CSR storage.
+        let src_indptr = constraint_matrix_csr.indptr();
+        let src_indices = constraint_matrix_csr.indices();
+        let src_data = constraint_matrix_csr.data();
+
+        let mut aug_indptr: Vec<usize> = Vec::with_capacity(num_constraints + 1);
+        // Upper bound on nnz: original nnz (for kept rows) + num_constraints (slack 1.0 each)
+        let mut aug_indices: Vec<usize> = Vec::new();
+        let mut aug_data: Vec<f64> = Vec::new();
+
+        aug_indptr.push(0);
+
+        for (slack_idx, &src_row) in kept_row_indices.iter().enumerate() {
+            let rhs = constraint_rhs[src_row];
+            let cmp_op = constraint_ops[src_row];
+
+            orig_rhs.push(rhs);
+
+            let (slack_var_min, slack_var_max) = match cmp_op {
+                ComparisonOp::Le => (0.0, f64::INFINITY),
+                ComparisonOp::Ge => (f64::NEG_INFINITY, 0.0),
+                ComparisonOp::Eq => (0.0, 0.0),
+            };
+
+            orig_var_mins.push(slack_var_min);
+            orig_var_maxs.push(slack_var_max);
+            basic_var_mins.push(slack_var_min);
+            basic_var_maxs.push(slack_var_max);
+
+            let cur_slack_var = var_states.len();
+            var_states.push(VarState::Basic(basic_vars.len()));
+            basic_vars.push(cur_slack_var);
+
+            // Compute lhs_val = sum(coeff * nb_var_vals[var]) for this row
+            let row_start = src_indptr.as_slice().unwrap()[src_row];
+            let row_end = src_indptr.as_slice().unwrap()[src_row + 1];
+            let mut lhs_val = 0.0;
+            for pos in row_start..row_end {
+                let col = src_indices[pos];
+                let coeff = src_data[pos];
+                // All original variables are non-basic at this point, with
+                // nb index == var index (they were added in order 0..num_vars).
+                lhs_val += coeff * nb_var_vals[col];
+            }
+            basic_var_vals.push(rhs - lhs_val);
+
+            // Append this row's entries to the augmented CSR arrays.
+            // Original columns first (already sorted in CSR), then the slack col.
+            for pos in row_start..row_end {
+                let col = src_indices[pos];
+                if col < num_total_vars {
+                    aug_indices.push(col);
+                    aug_data.push(src_data[pos]);
+                }
+            }
+            // Append slack column entry: column = num_vars + slack_idx, value = 1.0
+            let slack_col = num_vars + slack_idx;
+            aug_indices.push(slack_col);
+            aug_data.push(1.0);
+
+            aug_indptr.push(aug_indices.len());
+        }
+
+        let orig_constraints = CsMat::new(
+            (num_constraints, num_total_vars),
+            aug_indptr,
+            aug_indices,
+            aug_data,
+        );
+        let orig_constraints_csc = orig_constraints.to_csc();
+
+        // --- remainder is identical to try_new ---
+
+        let mut orig_obj_coeffs = obj_coeffs.to_vec();
+        orig_obj_coeffs.resize(num_total_vars, 0.0);
+
+        let is_primal_feasible = basic_var_vals
+            .iter()
+            .zip(&basic_var_mins)
+            .zip(&basic_var_maxs)
+            .all(|((&val, &min), &max)| val >= min && val <= max);
+
+        let need_artificial_obj = !is_primal_feasible && !is_dual_feasible;
+
+        let enable_dual_steepest_edge = enable_steepest_edge;
+        let dual_edge_sq_norms = if enable_dual_steepest_edge {
+            vec![1.0; basic_vars.len()]
+        } else {
+            vec![]
+        };
+
+        let enable_primal_steepest_edge = enable_steepest_edge && !is_dual_feasible;
+        let sq_norms_update_helper = if enable_primal_steepest_edge {
+            vec![0.0; num_total_vars - num_constraints]
+        } else {
+            vec![]
+        };
+
+        let mut nb_var_obj_coeffs = vec![];
+        let mut primal_edge_sq_norms = vec![];
+        for (&var, state) in nb_vars.iter().zip(&nb_var_states) {
+            let col = orig_constraints_csc.outer_view(var).unwrap();
+
+            if need_artificial_obj {
+                let coeff = if state.at_min && !state.at_max {
+                    1.0
+                } else if state.at_max && !state.at_min {
+                    -1.0
+                } else {
+                    0.0
+                };
+                nb_var_obj_coeffs.push(coeff);
+            } else {
+                nb_var_obj_coeffs.push(orig_obj_coeffs[var]);
+            }
+
+            if enable_primal_steepest_edge {
+                primal_edge_sq_norms.push(col.squared_l2_norm() + 1.0);
+            }
+        }
+
+        let cur_obj_val = if need_artificial_obj { 0.0 } else { obj_val };
+
+        let mut scratch = ScratchSpace::with_capacity(num_constraints);
+        let lu_factors = lu_factorize(
+            basic_vars.len(),
+            |c| {
+                orig_constraints_csc
+                    .outer_view(basic_vars[c])
+                    .unwrap()
+                    .into_raw_storage()
+            },
+            0.1,
+            &mut scratch,
+        )
+        .map_err(|e| Error::InternalError(e.to_string()))?;
+        let lu_factors_transp = lu_factors.transpose();
+
+        let nb_var_is_fixed = vec![false; nb_vars.len()];
+
+        let res = Self {
+            num_vars,
+            orig_obj_coeffs,
+            orig_var_mins,
+            orig_var_maxs,
+            orig_constraints,
+            orig_constraints_csc,
+            orig_rhs,
+            deadline,
+            orig_var_domains: var_domains.to_vec(),
+            enable_primal_steepest_edge,
+            enable_dual_steepest_edge,
+            is_primal_feasible,
+            is_dual_feasible,
+            var_states,
+            basis_solver: BasisSolver {
+                lu_factors,
+                lu_factors_transp,
+                scratch,
+                eta_matrices: EtaMatrices::new(num_constraints),
+                rhs: ScatteredVec::empty(num_constraints),
+            },
+            basic_vars,
+            basic_var_vals,
+            basic_var_mins,
+            basic_var_maxs,
+            dual_edge_sq_norms,
+            nb_vars,
+            nb_var_obj_coeffs,
+            nb_var_vals,
+            nb_var_states,
+            nb_var_is_fixed,
+            primal_edge_sq_norms,
+            cur_obj_val,
+            col_coeffs: SparseVec::new(),
+            sq_norms_update_helper,
+            inv_basis_row_coeffs: SparseVec::new(),
+            row_coeffs: ScatteredVec::empty(num_total_vars - num_constraints),
+        };
+
+        Ok(res)
+    }
+
+    pub(crate) fn get_value(&self, var: usize) -> &f64 {
+        match self.var_states[var] {
+            VarState::Basic(idx) => &self.basic_var_vals[idx],
+            VarState::NonBasic(idx) => &self.nb_var_vals[idx],
+        }
+    }
+
+    pub(crate) fn num_constraints(&self) -> usize {
+        self.orig_constraints.rows()
+    }
+
+    fn num_total_vars(&self) -> usize {
+        self.num_vars + self.num_constraints()
+    }
+
+    pub(crate) fn initial_solve(&mut self) -> Result<StopReason, Error> {
+        if check_deadline(&self.deadline) == StopReason::Limit {
+            return Ok(StopReason::Limit);
+        }
+
+        if !self.is_primal_feasible && self.restore_feasibility()? == StopReason::Limit {
+            return Ok(StopReason::Limit);
+        }
+
+        if !self.is_dual_feasible {
+            self.recalc_obj_coeffs()?;
+            if self.optimize()? == StopReason::Limit {
+                return Ok(StopReason::Limit);
+            }
+        }
+
+        self.enable_primal_steepest_edge = false;
+
+        Ok(StopReason::Finished)
+    }
+
+    fn optimize(&mut self) -> Result<StopReason, Error> {
+        for iter in 0.. {
+            if iter % 1000 == 0 {
+                if check_deadline(&self.deadline) == StopReason::Limit {
+                    return Ok(StopReason::Limit);
+                }
+            }
+
+            if let Some(pivot_info) = self.choose_pivot()? {
+                self.pivot(&pivot_info)?;
+            } else {
+                break;
+            }
+        }
+
+        self.is_dual_feasible = true;
+        Ok(StopReason::Finished)
+    }
+
+    fn restore_feasibility(&mut self) -> Result<StopReason, Error> {
+        for iter in 0.. {
+            if iter % 1000 == 0 {
+                if check_deadline(&self.deadline) == StopReason::Limit {
+                    return Ok(StopReason::Limit);
+                }
+            }
+
+            if let Some((row, leaving_new_val)) = self.choose_pivot_row_dual() {
+                self.calc_row_coeffs(row);
+                let pivot_info = self.choose_entering_col_dual(row, leaving_new_val)?;
+                self.calc_col_coeffs(pivot_info.col);
+                self.pivot(&pivot_info)?;
+            } else {
+                break;
+            }
+        }
+
+        self.is_primal_feasible = true;
+        Ok(StopReason::Finished)
+    }
+
+    pub(crate) fn add_constraint(
+        &mut self,
+        mut coeffs: CsVec,
+        cmp_op: ComparisonOp,
+        rhs: f64,
+    ) -> Result<StopReason, Error> {
+        assert!(self.is_primal_feasible);
+        assert!(self.is_dual_feasible);
+
+        if coeffs.indices().is_empty() {
+            let is_tautological = match cmp_op {
+                ComparisonOp::Eq => float_eq(rhs, 0.0),
+                ComparisonOp::Le => 0.0 <= rhs,
+                ComparisonOp::Ge => 0.0 >= rhs,
+            };
+
+            return if is_tautological {
+                Ok(StopReason::Finished)
+            } else {
+                Err(Error::Infeasible)
+            };
+        }
+
+        let slack_var = self.num_total_vars();
+        let (slack_var_min, slack_var_max) = match cmp_op {
+            ComparisonOp::Le => (0.0, f64::INFINITY),
+            ComparisonOp::Ge => (f64::NEG_INFINITY, 0.0),
+            ComparisonOp::Eq => (0.0, 0.0),
+        };
+
+        self.orig_obj_coeffs.push(0.0);
+        self.orig_var_mins.push(slack_var_min);
+        self.orig_var_maxs.push(slack_var_max);
+        self.var_states.push(VarState::Basic(self.basic_vars.len()));
+        self.basic_vars.push(slack_var);
+        self.basic_var_mins.push(slack_var_min);
+        self.basic_var_maxs.push(slack_var_max);
+
+        let mut lhs_val = 0.0;
+        for (var, &coeff) in coeffs.iter() {
+            let val = match self.var_states[var] {
+                VarState::Basic(idx) => self.basic_var_vals[idx],
+                VarState::NonBasic(idx) => self.nb_var_vals[idx],
+            };
+            lhs_val += val * coeff;
+        }
+        self.basic_var_vals.push(rhs - lhs_val);
+
+        let new_num_total_vars = self.num_total_vars() + 1;
+        let mut new_orig_constraints = CsMat::empty(CompressedStorage::CSR, new_num_total_vars);
+        for row in self.orig_constraints.outer_iterator() {
+            new_orig_constraints =
+                new_orig_constraints.append_outer_csvec(resized_view(&row, new_num_total_vars));
+        }
+        coeffs = into_resized(coeffs, new_num_total_vars);
+        coeffs.append(slack_var, 1.0);
+        new_orig_constraints = new_orig_constraints.append_outer_csvec(coeffs.view());
+
+        self.orig_rhs.push(rhs);
+
+        self.orig_constraints = new_orig_constraints;
+        self.orig_constraints_csc = self.orig_constraints.to_csc();
+
+        self.basis_solver
+            .reset(&self.orig_constraints_csc, &self.basic_vars)?;
+
+        if self.enable_primal_steepest_edge || self.enable_dual_steepest_edge {
+            self.calc_row_coeffs(self.num_constraints() - 1);
+
+            if self.enable_primal_steepest_edge {
+                for (c, &coeff) in self.row_coeffs.iter() {
+                    self.primal_edge_sq_norms[c] += coeff * coeff;
+                }
+            }
+
+            if self.enable_dual_steepest_edge {
+                self.dual_edge_sq_norms
+                    .push(self.inv_basis_row_coeffs.sq_norm());
+            }
+        }
+
+        self.is_primal_feasible = false;
+        self.restore_feasibility()
+    }
+
+    /// Number of infeasible basic vars and sum of their infeasibilities.
+    #[allow(dead_code)]
+    fn calc_primal_infeasibility(&self) -> (usize, f64) {
+        let mut num_vars = 0;
+        let mut infeasibility = 0.0;
+        for ((&val, &min), &max) in self
+            .basic_var_vals
+            .iter()
+            .zip(&self.basic_var_mins)
+            .zip(&self.basic_var_maxs)
+        {
+            if val < min - EPS {
+                num_vars += 1;
+                infeasibility += min - val;
+            } else if val > max + EPS {
+                num_vars += 1;
+                infeasibility += val - max;
+            }
+        }
+        (num_vars, infeasibility)
+    }
+
+    /// Number of infeasible obj. coeffs and sum of their infeasibilities.
+    #[allow(dead_code)]
+    fn calc_dual_infeasibility(&self) -> (usize, f64) {
+        let mut num_vars = 0;
+        let mut infeasibility = 0.0;
+        for (&obj_coeff, var_state) in self.nb_var_obj_coeffs.iter().zip(&self.nb_var_states) {
+            if !(var_state.at_min && obj_coeff > -EPS || var_state.at_max && obj_coeff < EPS) {
+                num_vars += 1;
+                infeasibility += obj_coeff.abs();
+            }
+        }
+        (num_vars, infeasibility)
+    }
+
+    /// Calculate current coeffs column for a single non-basic variable.
+    fn calc_col_coeffs(&mut self, c_var: usize) {
+        let var = self.nb_vars[c_var];
+        let orig_col = self.orig_constraints_csc.outer_view(var).unwrap();
+        self.basis_solver
+            .solve(orig_col.iter())
+            .to_sparse_vec(&mut self.col_coeffs);
+    }
+
+    /// Calculate current coeffs row for a single constraint (permuted according to nb_vars).
+    fn calc_row_coeffs(&mut self, r_constr: usize) {
+        self.basis_solver
+            .solve_transp(std::iter::once((r_constr, &1.0)))
+            .to_sparse_vec(&mut self.inv_basis_row_coeffs);
+
+        self.row_coeffs.clear_and_resize(self.nb_vars.len());
+        for (r, &coeff) in self.inv_basis_row_coeffs.iter() {
+            for (v, &val) in self.orig_constraints.outer_view(r).unwrap().iter() {
+                if let VarState::NonBasic(idx) = self.var_states[v] {
+                    *self.row_coeffs.get_mut(idx) += val * coeff;
+                }
+            }
+        }
+    }
+
+    fn choose_pivot(&mut self) -> Result<Option<PivotInfo>, Error> {
+        let entering_c = {
+            let filtered_obj_coeffs = self
+                .nb_var_obj_coeffs
+                .iter()
+                .zip(&self.nb_var_states)
+                .enumerate()
+                .filter_map(|(col, (&obj_coeff, var_state))| {
+                    if (var_state.at_min && obj_coeff > -EPS)
+                        || (var_state.at_max && obj_coeff < EPS)
+                    {
+                        None
+                    } else {
+                        Some((col, obj_coeff))
+                    }
+                });
+
+            let mut best_col = None;
+            let mut best_score = f64::NEG_INFINITY;
+            if self.enable_primal_steepest_edge {
+                for (col, obj_coeff) in filtered_obj_coeffs {
+                    let score = obj_coeff * obj_coeff / self.primal_edge_sq_norms[col];
+                    if score > best_score {
+                        best_col = Some(col);
+                        best_score = score;
+                    }
+                }
+            } else {
+                for (col, obj_coeff) in filtered_obj_coeffs {
+                    let score = obj_coeff.abs();
+                    if score > best_score {
+                        best_col = Some(col);
+                        best_score = score;
+                    }
+                }
+            }
+
+            if let Some(col) = best_col {
+                col
+            } else {
+                return Ok(None);
+            }
+        };
+
+        let entering_cur_val = self.nb_var_vals[entering_c];
+        let entering_diff_sign = self.nb_var_obj_coeffs[entering_c] < 0.0;
+        let entering_other_val = if entering_diff_sign {
+            self.orig_var_maxs[self.nb_vars[entering_c]]
+        } else {
+            self.orig_var_mins[self.nb_vars[entering_c]]
+        };
+
+        self.calc_col_coeffs(entering_c);
+
+        let get_leaving_var_step = |r: usize, coeff: f64| -> f64 {
+            let val = self.basic_var_vals[r];
+            if (entering_diff_sign && coeff < 0.0) || (!entering_diff_sign && coeff > 0.0) {
+                let max = self.basic_var_maxs[r];
+                if val < max { max - val } else { 0.0 }
+            } else {
+                let min = self.basic_var_mins[r];
+                if val > min { val - min } else { 0.0 }
+            }
+        };
+
+        // Harris rule
+        let mut max_step = (entering_other_val - entering_cur_val).abs();
+        for (r, &coeff) in self.col_coeffs.iter() {
+            let coeff_abs = coeff.abs();
+            if coeff_abs < EPS {
+                continue;
+            }
+
+            let cur_step = (get_leaving_var_step(r, coeff) + EPS) / coeff_abs;
+            if cur_step < max_step {
+                max_step = cur_step;
+            }
+        }
+
+        let mut leaving_r = None;
+        let mut leaving_new_val = 0.0;
+        let mut pivot_coeff_abs = f64::NEG_INFINITY;
+        let mut pivot_coeff = 0.0;
+        for (r, &coeff) in self.col_coeffs.iter() {
+            let coeff_abs = coeff.abs();
+            if coeff_abs < EPS {
+                continue;
+            }
+
+            let cur_step = get_leaving_var_step(r, coeff) / coeff_abs;
+            if cur_step <= max_step && coeff_abs > pivot_coeff_abs {
+                leaving_r = Some(r);
+                leaving_new_val = if (entering_diff_sign && coeff < 0.0)
+                    || (!entering_diff_sign && coeff > 0.0)
+                {
+                    self.basic_var_maxs[r]
+                } else {
+                    self.basic_var_mins[r]
+                };
+                pivot_coeff = coeff;
+                pivot_coeff_abs = coeff_abs;
+            }
+        }
+
+        if let Some(row) = leaving_r {
+            self.calc_row_coeffs(row);
+
+            let entering_diff = (self.basic_var_vals[row] - leaving_new_val) / pivot_coeff;
+            let entering_new_val = entering_cur_val + entering_diff;
+
+            Ok(Some(PivotInfo {
+                col: entering_c,
+                entering_new_val,
+                entering_diff,
+                elem: Some(PivotElem {
+                    row,
+                    coeff: pivot_coeff,
+                    leaving_new_val,
+                }),
+            }))
+        } else {
+            if entering_other_val.is_infinite() {
+                return Err(Error::Unbounded);
+            }
+
+            Ok(Some(PivotInfo {
+                col: entering_c,
+                entering_new_val: entering_other_val,
+                entering_diff: entering_other_val - entering_cur_val,
+                elem: None,
+            }))
+        }
+    }
+
+    fn choose_pivot_row_dual(&self) -> Option<(usize, f64)> {
+        let infeasibilities = self
+            .basic_var_vals
+            .iter()
+            .zip(&self.basic_var_mins)
+            .zip(&self.basic_var_maxs)
+            .enumerate()
+            .filter_map(|(r, ((&val, &min), &max))| {
+                if val < min - EPS {
+                    Some((r, min - val))
+                } else if val > max + EPS {
+                    Some((r, val - max))
+                } else {
+                    None
+                }
+            });
+
+        let mut leaving_r = None;
+        let mut max_score = f64::NEG_INFINITY;
+        if self.enable_dual_steepest_edge {
+            for (r, infeasibility) in infeasibilities {
+                let sq_norm = self.dual_edge_sq_norms[r];
+                let score = infeasibility * infeasibility / sq_norm;
+                if score > max_score {
+                    leaving_r = Some(r);
+                    max_score = score;
+                }
+            }
+        } else {
+            for (r, infeasibility) in infeasibilities {
+                if infeasibility > max_score {
+                    leaving_r = Some(r);
+                    max_score = infeasibility;
+                }
+            }
+        }
+
+        leaving_r.map(|r| {
+            let val = self.basic_var_vals[r];
+            let min = self.basic_var_mins[r];
+            let max = self.basic_var_maxs[r];
+
+            let new_val = if val < min {
+                min
+            } else if val > max {
+                max
+            } else {
+                unreachable!();
+            };
+            (r, new_val)
+        })
+    }
+
+    fn choose_entering_col_dual(
+        &self,
+        row: usize,
+        leaving_new_val: f64,
+    ) -> Result<PivotInfo, Error> {
+        let leaving_diff_sign = leaving_new_val > self.basic_var_vals[row];
+
+        fn clamp_obj_coeff(mut obj_coeff: f64, var_state: &NonBasicVarState) -> f64 {
+            if var_state.at_min && obj_coeff < 0.0 {
+                obj_coeff = 0.0;
+            }
+            if var_state.at_max && obj_coeff > 0.0 {
+                obj_coeff = 0.0;
+            }
+            obj_coeff
+        }
+
+        let is_eligible_var = |coeff: f64, var_state: &NonBasicVarState| -> bool {
+            let entering_diff_sign = if coeff >= EPS {
+                !leaving_diff_sign
+            } else if coeff <= -EPS {
+                leaving_diff_sign
+            } else {
+                return false;
+            };
+
+            if entering_diff_sign {
+                !var_state.at_max
+            } else {
+                !var_state.at_min
+            }
+        };
+
+        // Harris rule
+        let mut max_step = f64::INFINITY;
+        for (c, &coeff) in self.row_coeffs.iter() {
+            let var_state = &self.nb_var_states[c];
+            if !is_eligible_var(coeff, var_state) {
+                continue;
+            }
+
+            let obj_coeff = clamp_obj_coeff(self.nb_var_obj_coeffs[c], var_state);
+            let cur_step = (obj_coeff.abs() + EPS) / coeff.abs();
+            if cur_step < max_step {
+                max_step = cur_step;
+            }
+        }
+
+        let mut entering_c = None;
+        let mut pivot_coeff_abs = f64::NEG_INFINITY;
+        let mut pivot_coeff = 0.0;
+        for (c, &coeff) in self.row_coeffs.iter() {
+            let var_state = &self.nb_var_states[c];
+            if !is_eligible_var(coeff, var_state) {
+                continue;
+            }
+
+            let obj_coeff = clamp_obj_coeff(self.nb_var_obj_coeffs[c], var_state);
+
+            let cur_step = obj_coeff.abs() / coeff.abs();
+            if cur_step <= max_step {
+                let coeff_abs = coeff.abs();
+                if coeff_abs > pivot_coeff_abs {
+                    entering_c = Some(c);
+                    pivot_coeff_abs = coeff_abs;
+                    pivot_coeff = coeff;
+                }
+            }
+        }
+
+        if let Some(col) = entering_c {
+            let entering_diff = (self.basic_var_vals[row] - leaving_new_val) / pivot_coeff;
+            let entering_new_val = self.nb_var_vals[col] + entering_diff;
+
+            Ok(PivotInfo {
+                col,
+                entering_new_val,
+                entering_diff,
+                elem: Some(PivotElem {
+                    row,
+                    leaving_new_val,
+                    coeff: pivot_coeff,
+                }),
+            })
+        } else {
+            Err(Error::Infeasible)
+        }
+    }
+
+    fn pivot(&mut self, pivot_info: &PivotInfo) -> Result<(), Error> {
+        self.cur_obj_val += self.nb_var_obj_coeffs[pivot_info.col] * pivot_info.entering_diff;
+
+        let entering_var = self.nb_vars[pivot_info.col];
+
+        if pivot_info.elem.is_none() {
+            self.nb_var_vals[pivot_info.col] = pivot_info.entering_new_val;
+            for (r, coeff) in self.col_coeffs.iter() {
+                self.basic_var_vals[r] -= pivot_info.entering_diff * coeff;
+            }
+            let var_state = &mut self.nb_var_states[pivot_info.col];
+            var_state.at_min = float_eq(
+                pivot_info.entering_new_val,
+                self.orig_var_mins[entering_var],
+            );
+            var_state.at_max = float_eq(
+                pivot_info.entering_new_val,
+                self.orig_var_maxs[entering_var],
+            );
+            return Ok(());
+        }
+        let pivot_elem = pivot_info.elem.as_ref().unwrap();
+        let pivot_coeff = pivot_elem.coeff;
+
+        // Update basic vars stuff
+        for (r, coeff) in self.col_coeffs.iter() {
+            if r == pivot_elem.row {
+                self.basic_var_vals[r] = pivot_info.entering_new_val;
+            } else {
+                self.basic_var_vals[r] -= pivot_info.entering_diff * coeff;
+            }
+        }
+
+        self.basic_var_mins[pivot_elem.row] = self.orig_var_mins[entering_var];
+        self.basic_var_maxs[pivot_elem.row] = self.orig_var_maxs[entering_var];
+
+        if self.enable_dual_steepest_edge {
+            self.update_dual_sq_norms(pivot_elem.row, pivot_coeff);
+        }
+
+        // Update non-basic vars stuff
+        let leaving_var = self.basic_vars[pivot_elem.row];
+
+        self.nb_var_vals[pivot_info.col] = pivot_elem.leaving_new_val;
+        let leaving_var_state = &mut self.nb_var_states[pivot_info.col];
+        leaving_var_state.at_min =
+            float_eq(pivot_elem.leaving_new_val, self.orig_var_mins[leaving_var]);
+        leaving_var_state.at_max =
+            float_eq(pivot_elem.leaving_new_val, self.orig_var_maxs[leaving_var]);
+
+        let pivot_obj = self.nb_var_obj_coeffs[pivot_info.col] / pivot_coeff;
+        for (c, &coeff) in self.row_coeffs.iter() {
+            if c == pivot_info.col {
+                self.nb_var_obj_coeffs[c] = -pivot_obj;
+            } else {
+                self.nb_var_obj_coeffs[c] -= pivot_obj * coeff;
+            }
+        }
+
+        if self.enable_primal_steepest_edge {
+            self.update_primal_sq_norms(pivot_info.col, pivot_coeff);
+        }
+
+        // Update basis itself
+        self.basic_vars[pivot_elem.row] = entering_var;
+        self.var_states[entering_var] = VarState::Basic(pivot_elem.row);
+        self.nb_vars[pivot_info.col] = leaving_var;
+        self.var_states[leaving_var] = VarState::NonBasic(pivot_info.col);
+
+        let eta_matrices_nnz = self.basis_solver.eta_matrices.coeff_cols.nnz();
+        if eta_matrices_nnz < self.basis_solver.lu_factors.nnz() {
+            self.basis_solver
+                .push_eta_matrix(&self.col_coeffs, pivot_elem.row, pivot_coeff);
+        } else {
+            self.basis_solver
+                .reset(&self.orig_constraints_csc, &self.basic_vars)?;
+        }
+        Ok(())
+    }
+
+    fn update_primal_sq_norms(&mut self, entering_col: usize, pivot_coeff: f64) {
+        let tmp = self.basis_solver.solve_transp(self.col_coeffs.iter());
+
+        for &r in tmp.indices() {
+            for &v in self.orig_constraints.outer_view(r).unwrap().indices() {
+                if let VarState::NonBasic(idx) = self.var_states[v] {
+                    self.sq_norms_update_helper[idx] = 0.0;
+                }
+            }
+        }
+
+        for (r, &coeff) in tmp.iter() {
+            for (v, &val) in self.orig_constraints.outer_view(r).unwrap().iter() {
+                if let VarState::NonBasic(idx) = self.var_states[v] {
+                    self.sq_norms_update_helper[idx] += val * coeff;
+                }
+            }
+        }
+
+        let pivot_sq_norm = self.col_coeffs.sq_norm() + 1.0;
+
+        let pivot_coeff_sq = pivot_coeff * pivot_coeff;
+        for (c, &r_coeff) in self.row_coeffs.iter() {
+            if c == entering_col {
+                self.primal_edge_sq_norms[c] = pivot_sq_norm / pivot_coeff_sq;
+            } else {
+                self.primal_edge_sq_norms[c] += -2.0 * r_coeff * self.sq_norms_update_helper[c]
+                    / pivot_coeff
+                    + pivot_sq_norm * r_coeff * r_coeff / pivot_coeff_sq;
+            }
+
+            assert!(self.primal_edge_sq_norms[c].is_finite());
+        }
+    }
+
+    fn update_dual_sq_norms(&mut self, leaving_row: usize, pivot_coeff: f64) {
+        let tau = self.basis_solver.solve(self.inv_basis_row_coeffs.iter());
+
+        let pivot_sq_norm = self.inv_basis_row_coeffs.sq_norm();
+
+        let pivot_coeff_sq = pivot_coeff * pivot_coeff;
+        for (r, &col_coeff) in self.col_coeffs.iter() {
+            if r == leaving_row {
+                self.dual_edge_sq_norms[r] = pivot_sq_norm / pivot_coeff_sq;
+            } else {
+                self.dual_edge_sq_norms[r] += -2.0 * col_coeff * tau.get(r) / pivot_coeff
+                    + pivot_sq_norm * col_coeff * col_coeff / pivot_coeff_sq;
+            }
+
+            assert!(self.dual_edge_sq_norms[r].is_finite());
+        }
+    }
+
+    #[allow(dead_code)]
+    fn recalc_basic_var_vals(&mut self) -> Result<(), Error> {
+        let mut cur_vals = self.orig_rhs.clone();
+        for (i, var) in self.nb_vars.iter().enumerate() {
+            let val = self.nb_var_vals[i];
+            if val != 0.0 {
+                for (r, &coeff) in self.orig_constraints_csc.outer_view(*var).unwrap().iter() {
+                    cur_vals[r] -= val * coeff;
+                }
+            }
+        }
+
+        if self.basis_solver.eta_matrices.len() > 0 {
+            self.basis_solver
+                .reset(&self.orig_constraints_csc, &self.basic_vars)?;
+        }
+
+        self.basis_solver
+            .lu_factors
+            .solve_dense(&mut cur_vals, &mut self.basis_solver.scratch);
+        self.basic_var_vals = cur_vals;
+        Ok(())
+    }
+
+    fn recalc_obj_coeffs(&mut self) -> Result<(), Error> {
+        if self.basis_solver.eta_matrices.len() > 0 {
+            self.basis_solver
+                .reset(&self.orig_constraints_csc, &self.basic_vars)?;
+        }
+
+        let multipliers = {
+            let mut rhs = vec![0.0; self.num_constraints()];
+            for (c, &var) in self.basic_vars.iter().enumerate() {
+                rhs[c] = self.orig_obj_coeffs[var];
+            }
+            self.basis_solver
+                .lu_factors_transp
+                .solve_dense(&mut rhs, &mut self.basis_solver.scratch);
+            rhs
+        };
+
+        self.nb_var_obj_coeffs.clear();
+        for &var in &self.nb_vars {
+            let col = self.orig_constraints_csc.outer_view(var).unwrap();
+            let dot_prod: f64 = col.iter().map(|(r, val)| val * multipliers[r]).sum();
+            self.nb_var_obj_coeffs
+                .push(self.orig_obj_coeffs[var] - dot_prod);
+        }
+
+        self.cur_obj_val = 0.0;
+        for (r, &var) in self.basic_vars.iter().enumerate() {
+            self.cur_obj_val += self.orig_obj_coeffs[var] * self.basic_var_vals[r];
+        }
+        for (c, &var) in self.nb_vars.iter().enumerate() {
+            self.cur_obj_val += self.orig_obj_coeffs[var] * self.nb_var_vals[c];
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct PivotInfo {
+    col: usize,
+    entering_new_val: f64,
+    entering_diff: f64,
+    elem: Option<PivotElem>,
+}
+
+#[derive(Debug)]
+struct PivotElem {
+    row: usize,
+    coeff: f64,
+    leaving_new_val: f64,
+}
+
+/// Stuff related to inversion of the basis matrix
+#[derive(Clone)]
+struct BasisSolver {
+    lu_factors: LUFactors,
+    lu_factors_transp: LUFactors,
+    scratch: ScratchSpace,
+    eta_matrices: EtaMatrices,
+    rhs: ScatteredVec,
+}
+
+impl BasisSolver {
+    fn push_eta_matrix(&mut self, col_coeffs: &SparseVec, r_leaving: usize, pivot_coeff: f64) {
+        let coeffs = col_coeffs.iter().map(|(r, &coeff)| {
+            let val = if r == r_leaving {
+                1.0 - 1.0 / pivot_coeff
+            } else {
+                coeff / pivot_coeff
+            };
+            (r, val)
+        });
+        self.eta_matrices.push(r_leaving, coeffs);
+    }
+
+    fn reset(&mut self, orig_constraints_csc: &CsMat, basic_vars: &[usize]) -> Result<(), Error> {
+        self.scratch.clear_sparse(basic_vars.len());
+        self.eta_matrices.clear_and_resize(basic_vars.len());
+        self.rhs.clear_and_resize(basic_vars.len());
+        self.lu_factors = lu_factorize(
+            basic_vars.len(),
+            |c| {
+                orig_constraints_csc
+                    .outer_view(basic_vars[c])
+                    .unwrap()
+                    .into_raw_storage()
+            },
+            0.1,
+            &mut self.scratch,
+        )
+        .map_err(|e| Error::InternalError(e.to_string()))?;
+        self.lu_factors_transp = self.lu_factors.transpose();
+        Ok(())
+    }
+
+    fn solve<'a>(&mut self, rhs: impl Iterator<Item = (usize, &'a f64)>) -> &ScatteredVec {
+        self.rhs.set(rhs);
+        self.lu_factors.solve(&mut self.rhs, &mut self.scratch);
+
+        for idx in 0..self.eta_matrices.len() {
+            let r_leaving = self.eta_matrices.leaving_rows[idx];
+            let coeff = *self.rhs.get(r_leaving);
+            for (r, &val) in self.eta_matrices.coeff_cols.col_iter(idx) {
+                *self.rhs.get_mut(r) -= coeff * val;
+            }
+        }
+
+        &mut self.rhs
+    }
+
+    fn solve_transp<'a>(&mut self, rhs: impl Iterator<Item = (usize, &'a f64)>) -> &ScatteredVec {
+        self.rhs.set(rhs);
+        for idx in (0..self.eta_matrices.len()).rev() {
+            let mut coeff = 0.0;
+            for (i, &val) in self.eta_matrices.coeff_cols.col_iter(idx) {
+                coeff += val * self.rhs.get(i);
+            }
+            let r_leaving = self.eta_matrices.leaving_rows[idx];
+            *self.rhs.get_mut(r_leaving) -= coeff;
+        }
+
+        self.lu_factors_transp
+            .solve(&mut self.rhs, &mut self.scratch);
+        &mut self.rhs
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EtaMatrices {
+    leaving_rows: Vec<usize>,
+    coeff_cols: SparseMat,
+}
+
+impl EtaMatrices {
+    fn new(n_rows: usize) -> EtaMatrices {
+        EtaMatrices {
+            leaving_rows: vec![],
+            coeff_cols: SparseMat::new(n_rows),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.leaving_rows.len()
+    }
+
+    fn clear_and_resize(&mut self, n_rows: usize) {
+        self.leaving_rows.clear();
+        self.coeff_cols.clear_and_resize(n_rows);
+    }
+
+    fn push(&mut self, leaving_row: usize, coeffs: impl Iterator<Item = (usize, f64)>) {
+        self.leaving_rows.push(leaving_row);
+        self.coeff_cols.append_col(coeffs);
+    }
+}
+
+fn into_resized(vec: CsVec, len: usize) -> CsVec {
+    let (mut indices, mut data) = vec.into_raw_storage();
+
+    while let Some(&i) = indices.last() {
+        if i < len {
+            break;
+        }
+
+        indices.pop();
+        data.pop();
+    }
+
+    CsVec::new(len, indices, data)
+}

--- a/src/simplex/solver.rs
+++ b/src/simplex/solver.rs
@@ -11,10 +11,15 @@ use super::{
 };
 
 pub(crate) type CsVec = sprs::CsVecI<f64, usize>;
+/// Optional wall-clock deadline — if `Some`, the solver periodically checks
+/// whether the deadline has passed and returns `StopReason::Limit` if so.
 pub(crate) type Deadline = Option<Instant>;
 
 type CsMat = sprs::CsMatI<f64, usize>;
 
+/// Tolerances for floating-point comparisons. Values closer than `EPS` are
+/// considered equal. This avoids infinite cycling in the simplex algorithm
+/// caused by tiny rounding differences.
 pub(crate) const MACHINE_EPS: f64 = f64::EPSILON * 10.0;
 pub const EPS: f64 = if MACHINE_EPS > 1e-8 {
     MACHINE_EPS
@@ -39,60 +44,107 @@ fn check_deadline(deadline: &Deadline) -> StopReason {
     StopReason::Finished
 }
 
+/// Revised simplex method solver for linear programs of the form:
+///
+/// ```text
+///   minimise   c^T x
+///   subject to A x {≤, ≥, =} b
+///              lb ≤ x ≤ ub
+/// ```
+///
+/// The simplex method works by maintaining a "basis" — a subset of variables
+/// whose values are determined by the constraints (the rest sit at their
+/// bounds). Each iteration ("pivot") swaps one variable into the basis and
+/// one out, improving the objective until optimality is reached.
+///
+/// This solver supports both the **primal** simplex (used when the current
+/// solution is feasible but not optimal) and the **dual** simplex (used to
+/// restore feasibility after adding a constraint).
 #[derive(Clone)]
 pub(crate) struct Solver {
+    /// Number of original (non-slack) decision variables.
     pub(crate) num_vars: usize,
     pub(crate) deadline: Deadline,
 
+    // ── Problem data (immutable after construction) ──────────────────────
+    /// Objective function coefficients for all variables (original + slack).
     orig_obj_coeffs: Vec<f64>,
+    /// Lower bounds for all variables.
     orig_var_mins: Vec<f64>,
+    /// Upper bounds for all variables.
     orig_var_maxs: Vec<f64>,
     pub(crate) orig_var_domains: Vec<VarDomain>,
-    orig_constraints: CsMat, // excluding rhs
+    /// Constraint matrix in CSR format (rows = constraints, columns = all vars including slack).
+    orig_constraints: CsMat,
+    /// Same matrix in CSC format (for efficient column access during pivots).
     orig_constraints_csc: CsMat,
+    /// Right-hand side of each constraint.
     orig_rhs: Vec<f64>,
 
+    // ── Algorithm control ────────────────────────────────────────────────
+    /// Steepest-edge pricing: improves pivot selection at the cost of
+    /// maintaining squared norms. Generally makes the solver converge in
+    /// fewer iterations.
     enable_primal_steepest_edge: bool,
     enable_dual_steepest_edge: bool,
 
+    /// Feasibility flags — these determine which phase of the simplex
+    /// method is active (restore feasibility vs. optimise).
     is_primal_feasible: bool,
     is_dual_feasible: bool,
 
-    // Updated on each pivot
-    /// For each var: whether it is basic/non-basic and the corresponding index.
+    // ── Basis state (updated on each pivot) ──────────────────────────────
+    /// For each variable: whether it is basic or non-basic, and its index
+    /// within the corresponding array.
     var_states: Vec<VarState>,
+    /// LU factorisation of the current basis matrix, used to solve
+    /// `B * x = b` and `B^T * y = c` at each pivot.
     basis_solver: BasisSolver,
 
-    /// For each constraint the corresponding basic var.
+    /// For each constraint (row), the variable currently in the basis.
     basic_vars: Vec<usize>,
+    /// Current values of the basic variables.
     basic_var_vals: Vec<f64>,
     basic_var_mins: Vec<f64>,
     basic_var_maxs: Vec<f64>,
+    /// Squared norms for dual steepest-edge pricing.
     dual_edge_sq_norms: Vec<f64>,
 
-    /// Remaining variables. (idx -> var), 'nb' means 'non-basic'
+    /// Non-basic variables (the ones sitting at a bound). 'nb' = non-basic.
     nb_vars: Vec<usize>,
+    /// Reduced costs of the non-basic variables (how much the objective
+    /// improves per unit increase of each non-basic variable).
     nb_var_obj_coeffs: Vec<f64>,
     nb_var_vals: Vec<f64>,
     nb_var_states: Vec<NonBasicVarState>,
     nb_var_is_fixed: Vec<bool>,
+    /// Squared norms for primal steepest-edge pricing.
     primal_edge_sq_norms: Vec<f64>,
 
+    /// Current objective function value.
     pub(crate) cur_obj_val: f64,
 
-    // Recomputed on each pivot
+    // ── Scratch space (recomputed on each pivot) ─────────────────────────
+    /// Column of the basis-inverse times the entering variable's constraint column.
     col_coeffs: SparseVec,
     sq_norms_update_helper: Vec<f64>,
     inv_basis_row_coeffs: SparseVec,
+    /// Row of reduced costs for the leaving variable's constraint row.
     row_coeffs: ScatteredVec,
 }
 
+/// Tracks whether a variable is currently in the basis or not, and its
+/// index within the `basic_vars` or `nb_vars` array respectively.
 #[derive(Clone, Debug)]
 enum VarState {
+    /// In the basis — the `usize` is the index into `basic_vars` / `basic_var_vals`.
     Basic(usize),
+    /// Not in the basis — the `usize` is the index into `nb_vars` / `nb_var_vals`.
     NonBasic(usize),
 }
 
+/// For a non-basic variable, records whether it is currently sitting at
+/// its lower bound, upper bound, or neither (free variable).
 #[derive(Clone, Debug)]
 struct NonBasicVarState {
     at_min: bool,
@@ -692,6 +744,9 @@ impl Solver {
         self.num_vars + self.num_constraints()
     }
 
+    /// Run the full solve: first restore primal feasibility (dual simplex),
+    /// then optimise the objective (primal simplex). This is the main entry
+    /// point after constructing a Solver.
     pub(crate) fn initial_solve(&mut self) -> Result<StopReason, Error> {
         if check_deadline(&self.deadline) == StopReason::Limit {
             return Ok(StopReason::Limit);
@@ -713,6 +768,9 @@ impl Solver {
         Ok(StopReason::Finished)
     }
 
+    /// Primal simplex loop: repeatedly pick the best entering variable
+    /// (choose_pivot) and perform the basis exchange (pivot) until no
+    /// improving variable remains, meaning we've reached the optimum.
     fn optimize(&mut self) -> Result<StopReason, Error> {
         for iter in 0.. {
             if iter % 1000 == 0 {
@@ -732,6 +790,11 @@ impl Solver {
         Ok(StopReason::Finished)
     }
 
+    /// Dual simplex loop: used when the current solution is infeasible
+    /// (some basic variable violates its bounds). Each iteration picks the
+    /// most infeasible row (choose_pivot_row_dual), finds a compatible
+    /// entering column (choose_entering_col_dual), and pivots to reduce
+    /// infeasibility until all bounds are satisfied.
     fn restore_feasibility(&mut self) -> Result<StopReason, Error> {
         for iter in 0.. {
             if iter % 1000 == 0 {
@@ -754,6 +817,9 @@ impl Solver {
         Ok(StopReason::Finished)
     }
 
+    /// Add a new constraint to an already-solved LP and re-solve.
+    /// The new constraint gets a slack variable and enters the basis.
+    /// If adding it makes the solution infeasible, dual simplex restores feasibility.
     pub(crate) fn add_constraint(
         &mut self,
         mut coeffs: CsVec,
@@ -900,6 +966,18 @@ impl Solver {
         }
     }
 
+    /// Primal simplex pivot selection.
+    ///
+    /// 1. **Pick the entering variable**: the non-basic variable with the
+    ///    best reduced cost (using steepest-edge pricing if enabled).
+    /// 2. **Compute the pivot column**: solve `B * col = a_j` to get the
+    ///    representation of the entering column in the current basis.
+    /// 3. **Pick the leaving variable** (ratio test with Harris rule):
+    ///    find the basic variable that hits its bound first as the entering
+    ///    variable increases. The Harris rule adds a small tolerance to
+    ///    avoid degenerate pivots.
+    ///
+    /// Returns `None` when all reduced costs are non-improving → optimal.
     fn choose_pivot(&mut self) -> Result<Option<PivotInfo>, Error> {
         let entering_c = {
             let filtered_obj_coeffs = self
@@ -1034,6 +1112,8 @@ impl Solver {
         }
     }
 
+    /// Dual simplex: pick the leaving row — the basic variable with the
+    /// worst bound violation (weighted by steepest-edge norm if enabled).
     fn choose_pivot_row_dual(&self) -> Option<(usize, f64)> {
         let infeasibilities = self
             .basic_var_vals
@@ -1087,6 +1167,10 @@ impl Solver {
         })
     }
 
+    /// Dual simplex: given the leaving row, pick the entering column.
+    /// Uses the dual ratio test (with Harris rule) to find the non-basic
+    /// variable that maintains dual feasibility while allowing the leaving
+    /// variable to reach its bound.
     fn choose_entering_col_dual(
         &self,
         row: usize,
@@ -1176,6 +1260,13 @@ impl Solver {
         }
     }
 
+    /// Execute a basis exchange: swap the entering variable into the basis
+    /// and the leaving variable out. This updates all solver state:
+    /// - basic/non-basic variable values and bounds
+    /// - reduced costs (objective coefficients)
+    /// - steepest-edge norms (if enabled)
+    /// - the LU factorisation (either by appending an eta matrix or
+    ///   refactoring from scratch when eta fill-in gets too large)
     fn pivot(&mut self, pivot_info: &PivotInfo) -> Result<(), Error> {
         self.cur_obj_val += self.nb_var_obj_coeffs[pivot_info.col] * pivot_info.entering_diff;
 
@@ -1256,6 +1347,8 @@ impl Solver {
         Ok(())
     }
 
+    /// Incrementally update the squared steepest-edge norms for primal pricing
+    /// after a pivot. This avoids recomputing them from scratch each iteration.
     fn update_primal_sq_norms(&mut self, entering_col: usize, pivot_coeff: f64) {
         let tmp = self.basis_solver.solve_transp(self.col_coeffs.iter());
 
@@ -1291,6 +1384,7 @@ impl Solver {
         }
     }
 
+    /// Incrementally update the squared steepest-edge norms for dual pricing.
     fn update_dual_sq_norms(&mut self, leaving_row: usize, pivot_coeff: f64) {
         let tau = self.basis_solver.solve(self.inv_basis_row_coeffs.iter());
 
@@ -1333,6 +1427,10 @@ impl Solver {
         Ok(())
     }
 
+    /// Recompute the reduced costs of all non-basic variables from scratch.
+    /// Called when switching from the artificial objective (phase I) to
+    /// the real objective (phase II), or when accumulated rounding makes
+    /// incremental updates unreliable.
     fn recalc_obj_coeffs(&mut self) -> Result<(), Error> {
         if self.basis_solver.eta_matrices.len() > 0 {
             self.basis_solver
@@ -1369,32 +1467,53 @@ impl Solver {
     }
 }
 
+/// Everything needed to perform a single pivot operation.
 #[derive(Debug)]
 struct PivotInfo {
+    /// Non-basic index of the entering variable.
     col: usize,
+    /// Value the entering variable will take after the pivot.
     entering_new_val: f64,
+    /// Change in the entering variable's value (new - old).
     entering_diff: f64,
+    /// `None` when the entering variable simply moves to its other bound
+    /// without swapping with a basic variable (a "bound flip").
     elem: Option<PivotElem>,
 }
 
+/// Details of the basis exchange when a variable actually leaves the basis.
 #[derive(Debug)]
 struct PivotElem {
+    /// Constraint row of the leaving basic variable.
     row: usize,
+    /// The pivot element: coefficient of the entering variable in this row.
     coeff: f64,
+    /// Value the leaving variable will sit at after leaving the basis.
     leaving_new_val: f64,
 }
 
-/// Stuff related to inversion of the basis matrix
+/// Maintains the LU factorisation of the current basis matrix `B` and
+/// provides `solve(rhs)` → `B^{-1} * rhs` and `solve_transp(rhs)` → `B^{-T} * rhs`.
+///
+/// After each pivot, instead of refactoring from scratch, we append an
+/// "eta matrix" — a rank-1 correction that captures the basis change.
+/// When the accumulated eta matrices get too large (more non-zeros than
+/// the LU factors themselves), we refactor from scratch.
 #[derive(Clone)]
 struct BasisSolver {
     lu_factors: LUFactors,
+    /// Transposed LU factors, for solving `B^T * y = c` (needed for
+    /// reduced cost computation and steepest-edge updates).
     lu_factors_transp: LUFactors,
     scratch: ScratchSpace,
+    /// Accumulated rank-1 corrections since the last full refactorisation.
     eta_matrices: EtaMatrices,
+    /// Reusable working buffer for solve operations.
     rhs: ScatteredVec,
 }
 
 impl BasisSolver {
+    /// Record a rank-1 basis update instead of refactoring the full LU.
     fn push_eta_matrix(&mut self, col_coeffs: &SparseVec, r_leaving: usize, pivot_coeff: f64) {
         let coeffs = col_coeffs.iter().map(|(r, &coeff)| {
             let val = if r == r_leaving {
@@ -1407,6 +1526,8 @@ impl BasisSolver {
         self.eta_matrices.push(r_leaving, coeffs);
     }
 
+    /// Full LU refactorisation of the current basis matrix from scratch.
+    /// Called when eta fill-in exceeds the base LU size.
     fn reset(&mut self, orig_constraints_csc: &CsMat, basic_vars: &[usize]) -> Result<(), Error> {
         self.scratch.clear_sparse(basic_vars.len());
         self.eta_matrices.clear_and_resize(basic_vars.len());
@@ -1427,6 +1548,8 @@ impl BasisSolver {
         Ok(())
     }
 
+    /// Solve `B * x = rhs` where B is the current basis matrix.
+    /// First applies the base LU, then applies each accumulated eta correction.
     fn solve<'a>(&mut self, rhs: impl Iterator<Item = (usize, &'a f64)>) -> &ScatteredVec {
         self.rhs.set(rhs);
         self.lu_factors.solve(&mut self.rhs, &mut self.scratch);
@@ -1442,6 +1565,8 @@ impl BasisSolver {
         &mut self.rhs
     }
 
+    /// Solve `B^T * y = rhs` (the transpose system).
+    /// Eta corrections are applied in reverse order, then the transposed LU solve runs.
     fn solve_transp<'a>(&mut self, rhs: impl Iterator<Item = (usize, &'a f64)>) -> &ScatteredVec {
         self.rhs.set(rhs);
         for idx in (0..self.eta_matrices.len()).rev() {
@@ -1459,9 +1584,15 @@ impl BasisSolver {
     }
 }
 
+/// A sequence of eta (rank-1 update) matrices that accumulate between full
+/// LU refactorisations. Each eta matrix records one basis change: which row
+/// left and what coefficients changed. Applying them in order after the base
+/// LU solve gives the correct result for the current basis.
 #[derive(Clone, Debug)]
 struct EtaMatrices {
+    /// Which row left the basis in each successive pivot.
     leaving_rows: Vec<usize>,
+    /// The update coefficients for each pivot, stored column-wise.
     coeff_cols: SparseMat,
 }
 
@@ -1488,6 +1619,8 @@ impl EtaMatrices {
     }
 }
 
+/// Consume a sparse vector and return one truncated/extended to `len` dimensions.
+/// Entries with index >= len are dropped.
 fn into_resized(vec: CsVec, len: usize) -> CsVec {
     let (mut indices, mut data) = vec.into_raw_storage();
 

--- a/src/simplex/sparse.rs
+++ b/src/simplex/sparse.rs
@@ -4,6 +4,10 @@ use sprs::{CsMat, CsVec};
 
 use super::helpers::to_dense;
 
+/// A simple sparse vector stored as parallel `(index, value)` arrays.
+///
+/// Used throughout the simplex solver for intermediate results like
+/// column coefficients and pivot row data.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SparseVec {
     indices: Vec<usize>,
@@ -42,10 +46,20 @@ impl SparseVec {
     }
 }
 
+/// A dense-storage vector that also tracks which indices are non-zero.
+///
+/// Think of it as a dense `Vec<f64>` paired with a sparse index set.
+/// This gives O(1) random access (like a dense vec) while still allowing
+/// efficient iteration over only the non-zero entries (like a sparse vec).
+/// The simplex solver uses this as a working buffer during solve/transpose
+/// operations where both random access and sparse iteration are needed.
 #[derive(Clone, Debug)]
 pub struct ScatteredVec {
+    /// Dense storage — every index has a slot, most are 0.0.
     pub(crate) values: Vec<f64>,
+    /// Tracks which indices hold non-zero values.
     pub(crate) is_nonzero: Vec<bool>,
+    /// The indices that are currently non-zero (for sparse iteration).
     pub(crate) nonzero: Vec<usize>,
 }
 
@@ -125,12 +139,22 @@ impl ScatteredVec {
     }
 }
 
-/// Unordered sparse matrix with elements stored by columns
+/// Sparse matrix in compressed sparse column (CSC) format.
+///
+/// Elements are grouped by column. `indptr[c]..indptr[c+1]` gives the
+/// range in `indices`/`data` that belongs to column `c`. Within a column,
+/// entries may appear in any order (hence "unordered").
+///
+/// Columns are built incrementally: call [`push`] to add entries to the
+/// current column, then [`seal_column`] to finalize it and start the next.
 #[derive(Clone, Debug)]
 pub(crate) struct SparseMat {
     n_rows: usize,
+    /// Column pointers — `indptr[c]` is the start offset for column `c`.
     indptr: Vec<usize>,
+    /// Row indices of non-zero entries.
     indices: Vec<usize>,
+    /// Values of non-zero entries (parallel to `indices`).
     data: Vec<f64>,
 }
 
@@ -262,10 +286,17 @@ impl SparseMat {
     }
 }
 
+/// A triangular matrix (lower or upper), split into diagonal and off-diagonal parts.
+///
+/// Used to represent the L and U factors from LU decomposition.
+/// Storing the diagonal separately allows the solver to handle the common
+/// case where L has an implicit unit diagonal (all 1's) without wasting space.
 #[derive(Clone)]
 pub(crate) struct TriangleMat {
+    /// Off-diagonal entries, stored column-wise.
     pub(crate) nondiag: SparseMat,
-    /// Diag elements, None means all 1's
+    /// Diagonal elements. `None` means an implicit unit diagonal (all 1's),
+    /// which is the standard convention for the L factor.
     pub(crate) diag: Option<Vec<f64>>,
 }
 
@@ -297,14 +328,21 @@ impl std::fmt::Debug for TriangleMat {
     }
 }
 
+/// A permutation of row or column indices, stored as both the forward
+/// and inverse mappings so either direction is O(1).
 #[derive(Clone, Debug)]
 pub struct Perm {
+    /// Maps original index → permuted index.
     pub(crate) orig2new: Vec<usize>,
+    /// Maps permuted index → original index.
     pub(crate) new2orig: Vec<usize>,
 }
 
+/// Errors that can occur within the simplex solver's linear algebra layer.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
+    /// The basis matrix is singular — typically means the LP is degenerate
+    /// or malformed in a way that prevents factorisation.
     SingularMatrix,
 }
 impl Display for Error {

--- a/src/simplex/sparse.rs
+++ b/src/simplex/sparse.rs
@@ -1,0 +1,317 @@
+use std::fmt::{Display, Formatter};
+
+use sprs::{CsMat, CsVec};
+
+use super::helpers::to_dense;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SparseVec {
+    indices: Vec<usize>,
+    values: Vec<f64>,
+}
+
+impl SparseVec {
+    pub(crate) fn new() -> SparseVec {
+        SparseVec {
+            indices: vec![],
+            values: vec![],
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.indices.clear();
+        self.values.clear();
+    }
+
+    pub(crate) fn push(&mut self, i: usize, val: f64) {
+        self.indices.push(i);
+        self.values.push(val);
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (usize, &f64)> {
+        self.indices.iter().copied().zip(&self.values)
+    }
+
+    pub(crate) fn sq_norm(&self) -> f64 {
+        self.values.iter().map(|&v| v * v).sum()
+    }
+
+    pub(crate) fn into_csvec(self, len: usize) -> CsVec<f64> {
+        //guaranteed to not panic
+        CsVec::new_from_unsorted(len, self.indices, self.values).unwrap()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ScatteredVec {
+    pub(crate) values: Vec<f64>,
+    pub(crate) is_nonzero: Vec<bool>,
+    pub(crate) nonzero: Vec<usize>,
+}
+
+impl ScatteredVec {
+    pub fn empty(n: usize) -> ScatteredVec {
+        ScatteredVec {
+            values: vec![0.0; n],
+            is_nonzero: vec![false; n],
+            nonzero: vec![],
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (usize, &f64)> {
+        self.nonzero.iter().map(move |&i| (i, &self.values[i]))
+    }
+
+    pub fn indices(&self) -> &[usize] {
+        &self.nonzero
+    }
+
+    #[inline]
+    pub fn get(&self, i: usize) -> &f64 {
+        &self.values[i]
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, i: usize) -> &mut f64 {
+        if !std::mem::replace(&mut self.is_nonzero[i], true) {
+            self.nonzero.push(i);
+        }
+        &mut self.values[i]
+    }
+
+    pub fn sq_norm(&self) -> f64 {
+        self.nonzero
+            .iter()
+            .map(|&i| self.values[i] * self.values[i])
+            .sum()
+    }
+
+    pub fn clear(&mut self) {
+        for &i in &self.nonzero {
+            self.values[i] = 0.0;
+            self.is_nonzero[i] = false;
+        }
+        self.nonzero.clear();
+    }
+
+    pub fn clear_and_resize(&mut self, n: usize) {
+        self.clear();
+        self.values.resize(n, 0.0);
+        self.is_nonzero.resize(n, false);
+    }
+
+    pub fn set<'a, T>(&mut self, rhs: T)
+    where
+        T: IntoIterator<Item = (usize, &'a f64)>,
+    {
+        self.clear();
+        for (i, &val) in rhs {
+            self.is_nonzero[i] = true;
+            self.nonzero.push(i);
+            self.values[i] = val;
+        }
+    }
+
+    pub(crate) fn to_sparse_vec(&self, lhs: &mut SparseVec) {
+        lhs.clear();
+        for &idx in &self.nonzero {
+            lhs.indices.push(idx);
+            lhs.values.push(self.values[idx])
+        }
+    }
+}
+
+/// Unordered sparse matrix with elements stored by columns
+#[derive(Clone, Debug)]
+pub(crate) struct SparseMat {
+    n_rows: usize,
+    indptr: Vec<usize>,
+    indices: Vec<usize>,
+    data: Vec<f64>,
+}
+
+impl SparseMat {
+    pub(crate) fn new(n_rows: usize) -> SparseMat {
+        SparseMat {
+            n_rows,
+            indptr: vec![0],
+            indices: vec![],
+            data: vec![],
+        }
+    }
+
+    pub(crate) fn rows(&self) -> usize {
+        self.n_rows
+    }
+
+    pub(crate) fn cols(&self) -> usize {
+        self.indptr.len() - 1
+    }
+
+    pub(crate) fn nnz(&self) -> usize {
+        self.data.len()
+    }
+
+    pub(crate) fn clear_and_resize(&mut self, n_rows: usize) {
+        self.data.clear();
+        self.indices.clear();
+        self.indptr.clear();
+        self.indptr.push(0);
+        self.n_rows = n_rows;
+    }
+
+    pub(crate) fn push(&mut self, row: usize, val: f64) {
+        self.indices.push(row);
+        self.data.push(val);
+    }
+
+    pub(crate) fn seal_column(&mut self) {
+        self.indptr.push(self.indices.len())
+    }
+
+    pub(crate) fn col_rows(&self, i_col: usize) -> &[usize] {
+        &self.indices[self.indptr[i_col]..self.indptr[i_col + 1]]
+    }
+
+    pub(crate) fn col_rows_mut(&mut self, i_col: usize) -> &mut [usize] {
+        &mut self.indices[self.indptr[i_col]..self.indptr[i_col + 1]]
+    }
+
+    pub(crate) fn col_data(&self, i_col: usize) -> &[f64] {
+        &self.data[self.indptr[i_col]..self.indptr[i_col + 1]]
+    }
+
+    pub(crate) fn col_iter(&self, i_col: usize) -> impl Iterator<Item = (usize, &f64)> {
+        self.col_rows(i_col)
+            .iter()
+            .copied()
+            .zip(self.col_data(i_col))
+    }
+
+    pub(crate) fn append_col<T>(&mut self, col: T)
+    where
+        T: IntoIterator<Item = (usize, f64)>,
+    {
+        assert_eq!(*self.indptr.last().unwrap(), self.indices.len()); // prev column is sealed
+        for (idx, val) in col {
+            self.indices.push(idx);
+            self.data.push(val);
+        }
+        self.seal_column();
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn into_csmat(self) -> CsMat<f64> {
+        CsMat::new_csc(
+            (self.cols(), self.n_rows),
+            self.indptr,
+            self.indices,
+            self.data,
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn to_csmat(&self) -> CsMat<f64> {
+        self.clone().into_csmat()
+    }
+
+    pub(crate) fn transpose(&self) -> SparseMat {
+        let mut out = SparseMat {
+            n_rows: self.cols(),
+            indptr: vec![],
+            indices: vec![],
+            data: vec![],
+        };
+
+        // calculate row counts and store them in the indptr array.
+        out.indptr.clear();
+        out.indptr.resize(self.rows() + 1, 0);
+        for c in 0..self.cols() {
+            for &r in self.col_rows(c) {
+                out.indptr[r] += 1;
+            }
+        }
+
+        // calculate cumulative counts so that indptr elements point to
+        // the *ends* of each resulting row.
+        for r in 1..out.indptr.len() {
+            out.indptr[r] += out.indptr[r - 1];
+        }
+
+        // place the elements
+        out.indices.clear();
+        out.indices.resize(self.nnz(), 0);
+        out.data.clear();
+        out.data.resize(self.nnz(), 0.0);
+        for c in 0..self.cols() {
+            for (r, &val) in self.col_iter(c) {
+                out.indptr[r] -= 1;
+                out.indices[out.indptr[r]] = c;
+                out.data[out.indptr[r]] = val;
+            }
+        }
+
+        //guaranteed to have at least one element
+        *out.indptr.last_mut().unwrap() = self.nnz();
+
+        out
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TriangleMat {
+    pub(crate) nondiag: SparseMat,
+    /// Diag elements, None means all 1's
+    pub(crate) diag: Option<Vec<f64>>,
+}
+
+impl TriangleMat {
+    pub(crate) fn rows(&self) -> usize {
+        self.nondiag.rows()
+    }
+
+    pub(crate) fn cols(&self) -> usize {
+        self.nondiag.cols()
+    }
+
+    pub(crate) fn transpose(&self) -> TriangleMat {
+        TriangleMat {
+            nondiag: self.nondiag.transpose(),
+            diag: self.diag.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for TriangleMat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "nondiag:")?;
+        for row in self.nondiag.to_csmat().to_csr().outer_iterator() {
+            writeln!(f, "{:?}", to_dense(&row))?
+        }
+        writeln!(f, "diag: {:?}", self.diag)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Perm {
+    pub(crate) orig2new: Vec<usize>,
+    pub(crate) new2orig: Vec<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Error {
+    SingularMatrix,
+}
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let r = match self {
+            Error::SingularMatrix => "Singular matrix",
+        };
+        write!(f, "{}", r)
+    }
+}

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -301,10 +301,8 @@ mod tests {
         types::{ConsolidatedDemand, ConsolidatedLink},
     };
 
-    #[test]
-    fn test_solver_creation() {
-        // Create simple test data
-        let links = vec![ConsolidatedLink {
+    fn simple_links() -> Vec<ConsolidatedLink> {
+        vec![ConsolidatedLink {
             device1: "A".to_string(),
             device2: "B".to_string(),
             latency: 1.0,
@@ -313,9 +311,11 @@ mod tests {
             operator2: "Op1".to_string(),
             shared: 1,
             link_type: 0,
-        }];
+        }]
+    }
 
-        let demands = vec![ConsolidatedDemand {
+    fn simple_demands() -> Vec<ConsolidatedDemand> {
+        vec![ConsolidatedDemand {
             start: "A".to_string(),
             end: "B".to_string(),
             receivers: 1,
@@ -324,12 +324,15 @@ mod tests {
             kind: 1,
             multicast: false,
             original: 1,
-        }];
+        }]
+    }
 
+    #[test]
+    fn test_solver_creation() {
+        let links = simple_links();
+        let demands = simple_demands();
         let lp_builder = LpBuilderInput::new(&links, &demands);
-        let primitives = lp_builder
-            .build()
-            .expect("LP builder should succeed in tests");
+        let primitives = lp_builder.build().expect("LP builder should succeed");
         let solver = LpSolver::new(
             &primitives.cost,
             &primitives.a_eq,
@@ -337,7 +340,133 @@ mod tests {
             &primitives.a_ub,
             &primitives.b_ub,
         );
-
         assert!(solver.is_ok());
+    }
+
+    #[test]
+    fn test_rows_from_csc() {
+        // 2x3 matrix: [[1, 0, 2], [0, 3, 0]]
+        let matrix = CscMatrix::new(
+            2,
+            3,
+            vec![0, 1, 2, 3],    // colptr
+            vec![0, 1, 0],       // rowval
+            vec![1.0, 3.0, 2.0], // nzval
+        );
+        let rows = rows_from_csc(&matrix);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], vec![(0, 1.0), (2, 2.0)]); // row 0: col 0 = 1, col 2 = 2
+        assert_eq!(rows[1], vec![(1, 3.0)]); // row 1: col 1 = 3
+    }
+
+    #[test]
+    fn test_rows_from_csc_empty() {
+        let matrix = CscMatrix::new(3, 2, vec![0, 0, 0], vec![], vec![]);
+        let rows = rows_from_csc(&matrix);
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].is_empty());
+        assert!(rows[1].is_empty());
+        assert!(rows[2].is_empty());
+    }
+
+    #[test]
+    fn test_precomputed_rows() {
+        let links = simple_links();
+        let demands = simple_demands();
+        let lp_builder = LpBuilderInput::new(&links, &demands);
+        let primitives = lp_builder.build().expect("LP builder should succeed");
+        let precomputed = PrecomputedRows::new(&primitives);
+
+        // Should have rows matching the matrix dimensions
+        assert_eq!(precomputed.eq_rows.len(), primitives.a_eq.m);
+        assert_eq!(precomputed.ub_rows.len(), primitives.a_ub.m);
+    }
+
+    #[test]
+    fn test_coalition_buffers_new_and_reset() {
+        let mut buf = CoalitionBuffers::new(10);
+
+        assert_eq!(buf.col_remap.len(), 10);
+        assert!(buf.col_remap.iter().all(|&v| v == usize::MAX));
+        assert!(buf.cost.is_empty());
+
+        // Simulate use
+        buf.col_remap[0] = 0;
+        buf.col_remap[5] = 1;
+        buf.cost.push(1.0);
+        buf.cost.push(2.0);
+        buf.keep_rows.push(0);
+        buf.ops.push(ComparisonOp::Eq);
+        buf.rhs.push(5.0);
+
+        // Reset should clear everything
+        buf.reset();
+        assert!(buf.col_remap.iter().all(|&v| v == usize::MAX));
+        assert!(buf.cost.is_empty());
+        assert!(buf.keep_rows.is_empty());
+        assert!(buf.ops.is_empty());
+        assert!(buf.rhs.is_empty());
+
+        // Capacity should be preserved (no reallocation)
+        assert!(buf.cost.capacity() >= 10);
+    }
+
+    #[test]
+    fn test_solve_coalition_empty_columns() {
+        let links = simple_links();
+        let demands = simple_demands();
+        let lp_builder = LpBuilderInput::new(&links, &demands);
+        let primitives = lp_builder.build().expect("LP builder should succeed");
+        let precomputed = PrecomputedRows::new(&primitives);
+        let mut buffers = CoalitionBuffers::new(primitives.cost.len());
+
+        // Coalition mask 0 (no operators) — should fail with no columns
+        let col_masks = vec![0u32; primitives.cost.len()];
+        let row_masks = vec![0u32; primitives.b_ub.len()];
+
+        let result = solve_coalition(
+            &primitives,
+            &precomputed,
+            &mut buffers,
+            0, // empty coalition
+            &col_masks,
+            &col_masks,
+            &row_masks,
+            &row_masks,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_solve_coalition_grand_coalition() {
+        let links = simple_links();
+        let demands = simple_demands();
+        let lp_builder = LpBuilderInput::new(&links, &demands);
+        let primitives = lp_builder.build().expect("LP builder should succeed");
+        let precomputed = PrecomputedRows::new(&primitives);
+        let mut buffers = CoalitionBuffers::new(primitives.cost.len());
+
+        // All bits set — grand coalition, everything included
+        let all_bits = u32::MAX;
+        let col_masks = vec![all_bits; primitives.cost.len()];
+        let row_masks = vec![all_bits; primitives.b_ub.len()];
+
+        let result = solve_coalition(
+            &primitives,
+            &precomputed,
+            &mut buffers,
+            all_bits,
+            &col_masks,
+            &col_masks,
+            &row_masks,
+            &row_masks,
+        );
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.status, SolveStatus::Solved);
+        // Objective should be finite and non-zero for a feasible problem
+        assert!(result.objective_value.is_finite());
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,9 +1,70 @@
+use microlp::{ComparisonOp, StopReason, VarDomain};
+#[cfg(test)]
+use microlp::{OptimizationDirection, Variable};
+use sprs::TriMatI;
+
 use crate::{
     error::{Result, ShapleyError},
     lp_builder::LpPrimitives,
     sparse::CscMatrix,
 };
-use microlp::{ComparisonOp, OptimizationDirection, Variable};
+
+/// Pre-computed row-oriented representation of the LP constraint matrices.
+/// Built once from the full primitives, then reused for every coalition.
+pub(crate) struct PrecomputedRows {
+    /// Equality constraint rows: each entry is (original_col_index, coefficient)
+    eq_rows: Vec<Vec<(usize, f64)>>,
+    /// Inequality constraint rows: each entry is (original_col_index, coefficient)
+    ub_rows: Vec<Vec<(usize, f64)>>,
+}
+
+impl PrecomputedRows {
+    /// Build from the full (unfiltered) LP primitives. Call once before the coalition loop.
+    pub(crate) fn new(primitives: &LpPrimitives) -> Self {
+        Self {
+            eq_rows: rows_from_csc(&primitives.a_eq),
+            ub_rows: rows_from_csc(&primitives.a_ub),
+        }
+    }
+}
+
+/// Reusable per-thread buffers for coalition LP construction.
+pub(crate) struct CoalitionBuffers {
+    pub col_remap: Vec<usize>,
+    pub cost: Vec<f64>,
+    pub keep_rows: Vec<usize>,
+    pub var_mins: Vec<f64>,
+    pub var_maxs: Vec<f64>,
+    pub var_domains: Vec<VarDomain>,
+    pub ops: Vec<ComparisonOp>,
+    pub rhs: Vec<f64>,
+}
+
+impl CoalitionBuffers {
+    pub fn new(n_cols: usize) -> Self {
+        Self {
+            col_remap: vec![usize::MAX; n_cols],
+            cost: Vec::with_capacity(n_cols),
+            keep_rows: Vec::with_capacity(256),
+            var_mins: Vec::with_capacity(n_cols),
+            var_maxs: Vec::with_capacity(n_cols),
+            var_domains: Vec::with_capacity(n_cols),
+            ops: Vec::with_capacity(1024),
+            rhs: Vec::with_capacity(1024),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.col_remap.fill(usize::MAX);
+        self.cost.clear();
+        self.keep_rows.clear();
+        self.var_mins.clear();
+        self.var_maxs.clear();
+        self.var_domains.clear();
+        self.ops.clear();
+        self.rhs.clear();
+    }
+}
 
 /// Solver termination status
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,13 +73,16 @@ pub(crate) enum SolveStatus {
     Infeasible,
 }
 
-/// LP solver wrapper for microlp
+/// LP solver wrapper for microlp (used in tests)
+#[cfg(test)]
 pub(crate) struct LpSolver {
     problem: microlp::Problem,
 }
 
-/// Result of solving an LP
+/// Result of solving an LP (used in tests)
+#[cfg(test)]
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) struct LpSolution {
     pub status: SolveStatus,
     pub objective_value: f64,
@@ -38,6 +102,8 @@ fn rows_from_csc(matrix: &CscMatrix<f64>) -> Vec<Vec<(usize, f64)>> {
     rows
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 impl LpSolver {
     /// Create a new LP solver from individual components
     pub(crate) fn new(
@@ -90,152 +156,150 @@ impl LpSolver {
     }
 }
 
-/// Create LP solver for a specific coalition using precomputed bitmasks.
+/// Solve result from the coalition solver.
+pub(crate) struct CoalitionResult {
+    pub status: SolveStatus,
+    pub objective_value: f64,
+}
+
+/// Create and solve an LP for a specific coalition using pre-computed
+/// row-oriented constraint data. Avoids rebuilding CSC matrices per coalition.
 ///
 /// `coalition_mask` has bit i set for each operator i in the coalition,
 /// plus `ALWAYS_BIT` so that Public/Private/empty operators always match.
-pub(crate) fn create_coalition_solver(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn solve_coalition(
     primitives: &LpPrimitives,
+    precomputed: &PrecomputedRows,
+    buffers: &mut CoalitionBuffers,
     coalition_mask: u32,
     col_op1_mask: &[u32],
     col_op2_mask: &[u32],
     row_op1_mask: &[u32],
     row_op2_mask: &[u32],
-) -> Result<LpSolver> {
-    // Filter columns: keep if BOTH operators match the coalition
-    let keep_cols: Vec<usize> = (0..col_op1_mask.len())
-        .filter(|&i| {
-            (col_op1_mask[i] & coalition_mask) != 0 && (col_op2_mask[i] & coalition_mask) != 0
-        })
-        .collect();
+) -> Result<CoalitionResult> {
+    let n_cols = col_op1_mask.len();
 
-    if keep_cols.is_empty() {
+    buffers.reset();
+
+    // Ensure col_remap is large enough (may grow between calls if n_cols changes)
+    if buffers.col_remap.len() < n_cols {
+        buffers.col_remap.resize(n_cols, usize::MAX);
+    }
+
+    // Step 1: Compute keep_cols and build a remap array
+    let mut new_col = 0usize;
+
+    for i in 0..n_cols {
+        if (col_op1_mask[i] & coalition_mask) != 0 && (col_op2_mask[i] & coalition_mask) != 0 {
+            buffers.col_remap[i] = new_col;
+            buffers.cost.push(primitives.cost[i]);
+            new_col += 1;
+        }
+    }
+
+    if new_col == 0 {
         return Err(ShapleyError::MatrixConstructionError(
             "No columns selected for coalition".to_string(),
         ));
     }
 
-    // Filter rows for A_ub: keep if BOTH operators match the coalition
-    let keep_rows: Vec<usize> = (0..row_op1_mask.len())
-        .filter(|&i| {
-            (row_op1_mask[i] & coalition_mask) != 0 && (row_op2_mask[i] & coalition_mask) != 0
-        })
-        .collect();
-
-    // Filter constraint matrices
-    let a_eq_filtered = filter_columns(&primitives.a_eq, &keep_cols)?;
-    let a_ub_filtered = filter_rows_and_columns(&primitives.a_ub, &keep_rows, &keep_cols)?;
-
-    // Filter b_ub vector
-    let b_ub_filtered: Vec<f64> = keep_rows
-        .iter()
-        .filter_map(|&i| primitives.b_ub.get(i))
-        .copied()
-        .collect();
-
-    // Filter cost vector
-    let cost_filtered: Vec<f64> = keep_cols
-        .iter()
-        .filter_map(|&i| primitives.cost.get(i))
-        .copied()
-        .collect();
-
-    LpSolver::new(
-        &cost_filtered,
-        &a_eq_filtered,
-        &primitives.b_eq,
-        &a_ub_filtered,
-        &b_ub_filtered,
-    )
-}
-
-/// Filter columns of a CSC matrix
-fn filter_columns(matrix: &CscMatrix<f64>, keep: &[usize]) -> Result<CscMatrix<f64>> {
-    let mut col_ptr = vec![0];
-    let mut row_ind = Vec::new();
-    let mut values = Vec::new();
-
-    for &col in keep {
-        if col >= matrix.n {
-            return Err(ShapleyError::MatrixConstructionError(format!(
-                "Column index {col} out of bounds"
-            )));
-        }
-
-        let start = matrix.colptr[col];
-        let end = matrix.colptr[col + 1];
-
-        for idx in start..end {
-            row_ind.push(matrix.rowval[idx]);
-            values.push(matrix.nzval[idx]);
-        }
-
-        col_ptr.push(row_ind.len());
-    }
-
-    Ok(CscMatrix::new(
-        matrix.m,
-        keep.len(),
-        col_ptr,
-        row_ind,
-        values,
-    ))
-}
-
-/// Filter both rows and columns of a CSC matrix
-fn filter_rows_and_columns(
-    matrix: &CscMatrix<f64>,
-    keep_rows: &[usize],
-    keep_cols: &[usize],
-) -> Result<CscMatrix<f64>> {
-    // Create row mapping
-    let mut row_map = vec![None; matrix.m];
-    for (new_idx, &old_idx) in keep_rows.iter().enumerate() {
-        if old_idx < matrix.m {
-            row_map[old_idx] = Some(new_idx);
+    // Step 2: Compute keep_rows for A_ub
+    for i in 0..row_op1_mask.len() {
+        if (row_op1_mask[i] & coalition_mask) != 0 && (row_op2_mask[i] & coalition_mask) != 0 {
+            buffers.keep_rows.push(i);
         }
     }
 
-    let mut col_ptr = vec![0];
-    let mut row_ind = Vec::new();
-    let mut values = Vec::new();
+    let n_kept = new_col;
 
-    for &col in keep_cols {
-        if col >= matrix.n {
-            return Err(ShapleyError::MatrixConstructionError(format!(
-                "Column index {col} out of bounds"
-            )));
-        }
+    // Step 3: Build a single CSR constraint matrix via triplets, avoiding
+    // per-row CsVec allocations.
 
-        let start = matrix.colptr[col];
-        let end = matrix.colptr[col + 1];
+    let n_eq_rows = precomputed.eq_rows.len();
+    let n_ub_rows = buffers.keep_rows.len();
+    let n_total_rows = n_eq_rows + n_ub_rows;
 
-        for idx in start..end {
-            let row = matrix.rowval[idx];
-            // Only include if row is in keep_rows
-            if let Some(new_row) = row_map.get(row).and_then(|&r| r) {
-                row_ind.push(new_row);
-                values.push(matrix.nzval[idx]);
+    let mut triplets = TriMatI::<f64, usize>::new((n_total_rows, n_kept));
+    let mut row = 0;
+
+    // Equality constraints — all rows, remap columns
+    for (row_idx, entries) in precomputed.eq_rows.iter().enumerate() {
+        for &(old_col, val) in entries {
+            let nc = buffers.col_remap[old_col];
+            if nc != usize::MAX {
+                triplets.add_triplet(row, nc, val);
             }
         }
-
-        col_ptr.push(row_ind.len());
+        buffers.ops.push(ComparisonOp::Eq);
+        buffers.rhs.push(primitives.b_eq[row_idx]);
+        row += 1;
     }
 
-    Ok(CscMatrix::new(
-        keep_rows.len(),
-        keep_cols.len(),
-        col_ptr,
-        row_ind,
-        values,
-    ))
+    // Inequality constraints — only kept rows, remap columns
+    for keep_idx in 0..n_ub_rows {
+        let row_idx = buffers.keep_rows[keep_idx];
+        for &(old_col, val) in &precomputed.ub_rows[row_idx] {
+            let nc = buffers.col_remap[old_col];
+            if nc != usize::MAX {
+                triplets.add_triplet(row, nc, val);
+            }
+        }
+        buffers.ops.push(ComparisonOp::Le);
+        buffers.rhs.push(primitives.b_ub[row_idx]);
+        row += 1;
+    }
+
+    let constraint_matrix = triplets.to_csr();
+
+    // Build variable bounds and domains
+    buffers.var_mins.resize(n_kept, 0.0);
+    buffers.var_maxs.resize(n_kept, f64::INFINITY);
+    buffers.var_domains.resize(n_kept, VarDomain::Real);
+
+    // Solve using the vendored solver directly with pre-built CSR matrix
+    let solver_result = crate::simplex::solver::Solver::try_new_from_matrix(
+        &buffers.cost,
+        &buffers.var_mins,
+        &buffers.var_maxs,
+        constraint_matrix,
+        &buffers.ops,
+        &buffers.rhs,
+        &buffers.var_domains,
+        None,
+    );
+
+    match solver_result {
+        Ok(mut solver) => match solver.initial_solve() {
+            Ok(StopReason::Finished) => Ok(CoalitionResult {
+                status: SolveStatus::Solved,
+                objective_value: solver.cur_obj_val,
+            }),
+            Ok(StopReason::Limit) => Ok(CoalitionResult {
+                status: SolveStatus::Solved,
+                objective_value: solver.cur_obj_val,
+            }),
+            Err(microlp::Error::Infeasible) => Ok(CoalitionResult {
+                status: SolveStatus::Infeasible,
+                objective_value: 0.0,
+            }),
+            Err(e) => Err(ShapleyError::LpSolver(format!("LP solver error: {e}"))),
+        },
+        Err(microlp::Error::Infeasible) => Ok(CoalitionResult {
+            status: SolveStatus::Infeasible,
+            objective_value: 0.0,
+        }),
+        Err(e) => Err(ShapleyError::LpSolver(format!("LP solver error: {e}"))),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lp_builder::LpBuilderInput;
-    use crate::types::{ConsolidatedDemand, ConsolidatedLink};
+    use crate::{
+        lp_builder::LpBuilderInput,
+        types::{ConsolidatedDemand, ConsolidatedLink},
+    };
 
     #[test]
     fn test_solver_creation() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,7 @@
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize};
-
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize};
 
 pub type Demands = Vec<Demand>;
 pub type Devices = Vec<Device>;

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,9 +1,10 @@
+use std::collections::HashSet;
+
 use crate::{
     error::{Result, ShapleyError},
     types::{Demands, Devices, PrivateLinks, PublicLinks},
     utils::has_digit,
 };
-use std::collections::HashSet;
 
 /// Validate all inputs for network shapley computation
 pub(crate) fn check_inputs(

--- a/tests/csv_test.rs
+++ b/tests/csv_test.rs
@@ -1,9 +1,10 @@
+use std::fs::File;
+
 use network_shapley::{
     error::Result,
     shapley::{ShapleyInput, ShapleyOutput},
     types::{Demand, Demands, Device, Devices, PrivateLink, PrivateLinks, PublicLink, PublicLinks},
 };
-use std::fs::File;
 use tabled::{builder::Builder as TableBuilder, settings::Style};
 
 fn read_pvt_links(file_path: &str) -> Result<PrivateLinks> {

--- a/tests/csv_test.rs
+++ b/tests/csv_test.rs
@@ -96,15 +96,15 @@ fn test_csv_demand1() {
         .to_string();
     println!("{table}");
 
-    // Expected values from Python output
-    assert_shapley_value(&result, "Alpha", 21.5370, 0.0208);
-    assert_shapley_value(&result, "Beta", 10.6595, 0.0103);
-    assert_shapley_value(&result, "Delta", 13.5257, 0.0131);
+    // Expected values (uptime penalty applied inside network-shapley-rs)
+    assert_shapley_value(&result, "Alpha", 20.7043, 0.0224);
+    assert_shapley_value(&result, "Beta", 10.6595, 0.0115);
+    assert_shapley_value(&result, "Delta", 13.4308, 0.0145);
     assert_shapley_value(&result, "Epsilon", 0.0407, 0.0000);
-    assert_shapley_value(&result, "Gamma", 487.1094, 0.4701);
-    assert_shapley_value(&result, "Kappa", 0.0603, 0.0001);
-    assert_shapley_value(&result, "Theta", 503.1153, 0.4855);
-    assert_shapley_value(&result, "Zeta", 0.1393, 0.0001);
+    assert_shapley_value(&result, "Gamma", 385.4550, 0.4164);
+    assert_shapley_value(&result, "Kappa", 0.0000, 0.0000);
+    assert_shapley_value(&result, "Theta", 495.3964, 0.5351);
+    assert_shapley_value(&result, "Zeta", 0.0445, 0.0000);
 }
 
 #[test]
@@ -131,13 +131,13 @@ fn test_csv_demand2() {
         .to_string();
     println!("{table}");
 
-    // Expected values from Python output
-    assert_shapley_value(&result, "Alpha", 2.0154, 0.0016);
-    assert_shapley_value(&result, "Beta", 187.1198, 0.1501);
-    assert_shapley_value(&result, "Delta", 111.6727, 0.0895);
-    assert_shapley_value(&result, "Epsilon", 88.5022, 0.0709);
-    assert_shapley_value(&result, "Gamma", 23.0343, 0.0184);
-    assert_shapley_value(&result, "Kappa", 10.6421, 0.0085);
-    assert_shapley_value(&result, "Theta", 333.5522, 0.2675);
-    assert_shapley_value(&result, "Zeta", 490.0349, 0.3931);
+    // Expected values (uptime penalty applied inside network-shapley-rs)
+    assert_shapley_value(&result, "Alpha", 2.3309, 0.0019);
+    assert_shapley_value(&result, "Beta", 168.2600, 0.1353);
+    assert_shapley_value(&result, "Delta", 109.1948, 0.0878);
+    assert_shapley_value(&result, "Epsilon", 96.5958, 0.0777);
+    assert_shapley_value(&result, "Gamma", 24.3389, 0.0196);
+    assert_shapley_value(&result, "Kappa", 10.6422, 0.0086);
+    assert_shapley_value(&result, "Theta", 333.2760, 0.2680);
+    assert_shapley_value(&result, "Zeta", 498.7059, 0.4011);
 }

--- a/tests/python_parity.py
+++ b/tests/python_parity.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Run the Python network_shapley on test fixtures and output JSON for comparison.
+
+Used by the Rust parity test (python_parity_test.rs) to validate that
+both implementations produce identical results from the same inputs.
+
+Requires: pip install pandas scipy
+"""
+import json
+import sys
+import os
+
+# Find the Python network_shapley module — check common locations
+SEARCH_PATHS = [
+    os.path.join(os.path.dirname(__file__), "..", "..", "network-shapley-py"),
+    os.path.join(os.path.dirname(__file__), "..", "..", "network-shapley"),
+    os.environ.get("NETWORK_SHAPLEY_PY_PATH", ""),
+]
+
+for path in SEARCH_PATHS:
+    if path and os.path.isfile(os.path.join(path, "network_shapley.py")):
+        sys.path.insert(0, path)
+        break
+
+import warnings
+warnings.filterwarnings("ignore")
+
+import pandas as pd
+from network_shapley import network_shapley
+
+TEST_DIR = os.path.join(os.path.dirname(__file__))
+
+
+def run_scenario(demand_file: str, multiplier: float) -> dict:
+    devices = pd.read_csv(os.path.join(TEST_DIR, "devices.csv"))
+    devices.columns = ["Device", "Edge", "Operator"]
+
+    private_links = pd.read_csv(os.path.join(TEST_DIR, "private_links.csv"))
+    private_links.columns = ["Device1", "Device2", "Latency", "Bandwidth", "Uptime", "Shared"]
+
+    public_links = pd.read_csv(os.path.join(TEST_DIR, "public_links.csv"))
+    public_links.columns = ["City1", "City2", "Latency"]
+
+    demand = pd.read_csv(os.path.join(TEST_DIR, demand_file))
+    demand.columns = ["Start", "End", "Receivers", "Traffic", "Priority", "Type", "Multicast"]
+
+    result = network_shapley(
+        private_links=private_links,
+        devices=devices,
+        demand=demand,
+        public_links=public_links,
+        operator_uptime=0.98,
+        contiguity_bonus=5.0,
+        demand_multiplier=multiplier,
+    )
+
+    return {row["Operator"]: row["Value"] for _, row in result.iterrows()}
+
+
+if __name__ == "__main__":
+    output = {
+        "demand1_1x": run_scenario("demand1.csv", 1.0),
+        "demand1_1.2x": run_scenario("demand1.csv", 1.2),
+        "demand2_1x": run_scenario("demand2.csv", 1.0),
+        "demand2_1.2x": run_scenario("demand2.csv", 1.2),
+    }
+    print(json.dumps(output))

--- a/tests/python_parity_test.rs
+++ b/tests/python_parity_test.rs
@@ -46,19 +46,30 @@ fn run_rust_shapley(demand_file: &str, multiplier: f64) -> BTreeMap<String, f64>
     result.into_iter().map(|(op, sv)| (op, sv.value)).collect()
 }
 
-fn run_python_shapley() -> BTreeMap<String, BTreeMap<String, f64>> {
-    let output = Command::new("python3")
+/// Returns None if Python or required deps (pandas, scipy) are not available.
+fn run_python_shapley() -> Option<BTreeMap<String, BTreeMap<String, f64>>> {
+    let output = match Command::new("python3")
         .arg("tests/python_parity.py")
         .output()
-        .expect("Failed to run python3 — is Python 3 installed?");
+    {
+        Ok(o) => o,
+        Err(_) => {
+            eprintln!("SKIP: python3 not found");
+            return None;
+        }
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("ModuleNotFoundError") {
+            eprintln!("SKIP: Python deps not installed (pandas/scipy)");
+            return None;
+        }
         panic!("Python parity script failed:\n{stderr}");
     }
 
     let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8 from Python");
-    serde_json::from_str(&stdout).expect("Failed to parse Python JSON output")
+    Some(serde_json::from_str(&stdout).expect("Failed to parse Python JSON output"))
 }
 
 fn compare_results(scenario: &str, rust: &BTreeMap<String, f64>, python: &BTreeMap<String, f64>) {
@@ -95,7 +106,13 @@ fn compare_results(scenario: &str, rust: &BTreeMap<String, f64>, python: &BTreeM
 
 #[test]
 fn test_rust_python_parity() {
-    let python_results = run_python_shapley();
+    let python_results = match run_python_shapley() {
+        Some(r) => r,
+        None => {
+            eprintln!("Skipping parity test — Python or deps not available");
+            return;
+        }
+    };
 
     // Scenario: demand1 with multiplier 1.0
     let rust = run_rust_shapley("tests/demand1.csv", 1.0);

--- a/tests/python_parity_test.rs
+++ b/tests/python_parity_test.rs
@@ -1,0 +1,127 @@
+//! Parity test: validates that Rust and Python implementations produce identical
+//! Shapley values from the same CSV inputs.
+//!
+//! Requires Python 3 with pandas and scipy installed, plus the network-shapley-py
+//! repo accessible (see tests/python_parity.py for search paths).
+//!
+//! Run with: cargo test --features serde --test python_parity_test
+//! Skip with: cargo test --test python_parity_test -- --ignored (if Python unavailable)
+
+use std::{collections::BTreeMap, fs::File, process::Command};
+
+use network_shapley::{
+    shapley::ShapleyInput,
+    types::{Demand, Device, PrivateLink, PublicLink},
+};
+
+/// Tolerance for value comparison. Values within this absolute difference
+/// are considered identical (accounts for floating-point representation).
+const VALUE_TOLERANCE: f64 = 0.01;
+
+fn read_csv<T: serde::de::DeserializeOwned>(path: &str) -> Vec<T> {
+    let file = File::open(path).unwrap_or_else(|e| panic!("Failed to open {path}: {e}"));
+    csv::Reader::from_reader(file)
+        .deserialize()
+        .map(|r| r.unwrap())
+        .collect()
+}
+
+fn run_rust_shapley(demand_file: &str, multiplier: f64) -> BTreeMap<String, f64> {
+    let private_links: Vec<PrivateLink> = read_csv("tests/private_links.csv");
+    let devices: Vec<Device> = read_csv("tests/devices.csv");
+    let public_links: Vec<PublicLink> = read_csv("tests/public_links.csv");
+    let demands: Vec<Demand> = read_csv(demand_file);
+
+    let input = ShapleyInput {
+        private_links,
+        devices,
+        demands,
+        public_links,
+        operator_uptime: 0.98,
+        contiguity_bonus: 5.0,
+        demand_multiplier: multiplier,
+    };
+
+    let result = input.compute().expect("Shapley computation failed");
+    result.into_iter().map(|(op, sv)| (op, sv.value)).collect()
+}
+
+fn run_python_shapley() -> BTreeMap<String, BTreeMap<String, f64>> {
+    let output = Command::new("python3")
+        .arg("tests/python_parity.py")
+        .output()
+        .expect("Failed to run python3 — is Python 3 installed?");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("Python parity script failed:\n{stderr}");
+    }
+
+    let stdout = String::from_utf8(output.stdout).expect("Invalid UTF-8 from Python");
+    serde_json::from_str(&stdout).expect("Failed to parse Python JSON output")
+}
+
+fn compare_results(scenario: &str, rust: &BTreeMap<String, f64>, python: &BTreeMap<String, f64>) {
+    assert_eq!(
+        rust.len(),
+        python.len(),
+        "{scenario}: operator count mismatch: Rust={}, Python={}",
+        rust.len(),
+        python.len()
+    );
+
+    let mut max_diff = 0.0f64;
+    let mut max_diff_op = String::new();
+
+    for (op, &rv) in rust {
+        let &pv = python
+            .get(op)
+            .unwrap_or_else(|| panic!("{scenario}: operator {op} missing from Python output"));
+
+        let diff = (rv - pv).abs();
+        if diff > max_diff {
+            max_diff = diff;
+            max_diff_op = op.clone();
+        }
+
+        assert!(
+            diff < VALUE_TOLERANCE,
+            "{scenario}: value mismatch for {op}: Rust={rv:.6}, Python={pv:.6}, diff={diff:.6} (tolerance={VALUE_TOLERANCE})",
+        );
+    }
+
+    eprintln!("{scenario}: PASS (max diff={max_diff:.8} on {max_diff_op})");
+}
+
+#[test]
+fn test_rust_python_parity() {
+    let python_results = run_python_shapley();
+
+    // Scenario: demand1 with multiplier 1.0
+    let rust = run_rust_shapley("tests/demand1.csv", 1.0);
+    let python = python_results
+        .get("demand1_1x")
+        .expect("Missing demand1_1x from Python");
+    compare_results("demand1 (1.0x)", &rust, python);
+
+    // Scenario: demand1 with multiplier 1.2
+    let rust = run_rust_shapley("tests/demand1.csv", 1.2);
+    let python = python_results
+        .get("demand1_1.2x")
+        .expect("Missing demand1_1.2x from Python");
+    compare_results("demand1 (1.2x)", &rust, python);
+
+    // Scenario: demand2 with multiplier 1.0
+    let rust = run_rust_shapley("tests/demand2.csv", 1.0);
+    let python = python_results
+        .get("demand2_1x")
+        .expect("Missing demand2_1x from Python");
+    compare_results("demand2 (1.0x)", &rust, python);
+
+    // Scenario: demand2 with multiplier 1.2
+    let rust = run_rust_shapley("tests/demand2.csv", 1.2);
+    let python = python_results
+        .get("demand2_1.2x")
+        .expect("Missing demand2_1.2x from Python");
+    compare_results("demand2 (1.2x)", &rust, python);
+}


### PR DESCRIPTION
This PR adds a few performance optimizations and moves the link penalty function to this crate, mirroring the python implementation.

Optimizations:
  * Pre-computed row-oriented constraint form — eliminated per-coalition CSC matrix reconstruction. 15% faster (15:06 → 12:48)
  * LP construction rewrite — vendored microlp's Solver into src/simplex/, bypassed the Problem builder API, and called Solver::try_new_from_matrix directly with a one-shot CSR constraint matrix via sprs::TriMatI. 28% faster  overall (15:06 → 10:48).

## Tests
* Added _parity tests to help ensure implementations stay in sync